### PR TITLE
Remove Guava predicates and fix IntelliJ warnings

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java temurin-17.0.19+10


### PR DESCRIPTION
## Summary

- Replace Guava predicate utilities with standard Java equivalents (`org.ethelred.util.Predicates`)
- Fix IntelliJ-flagged warnings across the codebase
- Pin Java 17 in `.tool-versions` for Gradle 7.5.1 compatibility

## Test plan

- [x] `./gradlew build` passes with Java 17

🤖 Generated with [Claude Code](https://claude.com/claude-code)