### PR TITLE
Update CI workflow to target main branch

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,9 +5,9 @@ name: Java CI with Gradle
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Updates `push` and `pull_request` triggers in the CI workflow from `master` → `main` in preparation for renaming the default branch.

## Test plan
- [ ] Verify CI runs on this PR (targets `master` still, so it should trigger)
- [ ] After merging and renaming the default branch to `main`, verify CI triggers on pushes to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)