### PR TITLE
Remove stale MANIFEST.MF, fix Java toolchain version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.jmock', name: 'jmock', version: '2.13.1'
-    testImplementation group: 'org.jmock', name: 'jmock-legacy', version: '2.13.1'
+    testImplementation group: 'org.jmock', name: 'jmock-imposters', version: '2.13.1'
 
 //    rewrite('org.ethelred:ethelred-rewrite:0.3-6-ga72db15.dirty')
     rewrite("org.openrewrite.recipe:rewrite-logging-frameworks:latest.release")

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(11)
+        languageVersion = JavaLanguageVersion.of(17)
     }
 }
 

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,8 +1,0 @@
-Manifest-Version: 1.0
-Class-Path: jmock-2.5.1.jar bsh-core-2.0b4.jar cglib-nodep-2.1_3.jar h
- amcrest-core-1.1.jar hamcrest-library-1.1.jar jmock-junit3-2.5.1.jar 
- jmock-junit4-2.5.1.jar jmock-legacy-2.5.1.jar jmock-script-2.5.1.jar 
- objenesis-1.0.jar mail.jar args4j-2.0.8.jar guava-11.0.1.jar joda-tim
- e-2.1.jar
-Main-Class: org.ethelred.mymailtool2.Main
-

--- a/src/test/java/org/ethelred/mymailtool2/ApplyMatchOperationsTaskTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/ApplyMatchOperationsTaskTest.java
@@ -9,7 +9,7 @@ import org.ethelred.mymailtool2.mock.MockDefaultConfiguration;
 import org.ethelred.mymailtool2.mock.MockMessage;
 import org.ethelred.util.ClockFactory;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.After;
 import org.junit.Test;
 

--- a/src/test/java/org/ethelred/mymailtool2/MailUtilTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/MailUtilTest.java
@@ -7,7 +7,7 @@ import jakarta.mail.MessagingException;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -17,7 +17,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class MailUtilTest
 {
-    Mockery context = new Mockery(){{setImposteriser(ClassImposteriser.INSTANCE);}};
+    Mockery context = new Mockery(){{setImposteriser(ByteBuddyClassImposteriser.INSTANCE);}};
 
     @Test
     public void messageToString() throws MessagingException

--- a/src/test/java/org/ethelred/mymailtool2/MainTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/MainTest.java
@@ -3,7 +3,7 @@ package org.ethelred.mymailtool2;
 import org.ethelred.util.ClockFactory;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.joda.time.DateMidnight;
 import org.joda.time.DateTime;
 import org.junit.Test;
@@ -22,7 +22,7 @@ import static org.junit.Assert.fail;
  */
 public class MainTest
 {
-    Mockery my = new Mockery(){{setImposteriser(ClassImposteriser.INSTANCE);}};
+    Mockery my = new Mockery(){{setImposteriser(ByteBuddyClassImposteriser.INSTANCE);}};
 
     @Test
     public void testOperationLimit()

--- a/src/test/java/org/ethelred/mymailtool2/MatchOperationTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/MatchOperationTest.java
@@ -4,7 +4,7 @@ import jakarta.mail.Message;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Test;
 
 import java.util.function.Predicate;
@@ -14,7 +14,7 @@ import java.util.function.Predicate;
  */
 public class MatchOperationTest
 {
-    Mockery context = new Mockery(){{setImposteriser(ClassImposteriser.INSTANCE);}};
+    Mockery context = new Mockery(){{setImposteriser(ByteBuddyClassImposteriser.INSTANCE);}};
 
     @Test
     public void testSuccess()

--- a/src/test/java/org/ethelred/mymailtool2/MessageOperationsTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/MessageOperationsTest.java
@@ -9,7 +9,7 @@ import jakarta.mail.MessagingException;
 
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.joda.time.LocalDate;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +23,7 @@ import static org.junit.Assert.fail;
  */
 public class MessageOperationsTest
 {
-    Mockery context = new Mockery(){{setImposteriser(ClassImposteriser.INSTANCE);}};
+    Mockery context = new Mockery(){{setImposteriser(ByteBuddyClassImposteriser.INSTANCE);}};
 
     Message msg;
     Folder startingFolder;

--- a/src/test/java/org/ethelred/mymailtool2/TaskBaseTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/TaskBaseTest.java
@@ -6,7 +6,7 @@ import org.ethelred.mymailtool2.mock.MockMessage;
 import org.ethelred.mymailtool2.mock.MockStore;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/ethelred/mymailtool2/matcher/MatchersTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/matcher/MatchersTest.java
@@ -7,7 +7,7 @@ import jakarta.mail.MessagingException;
 import java.util.function.Predicate;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
-import org.jmock.lib.legacy.ClassImposteriser;
+import org.jmock.imposters.ByteBuddyClassImposteriser;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -20,7 +20,7 @@ import static org.junit.Assert.fail;
  */
 public class MatchersTest
 {
-    Mockery context = new Mockery(){{setImposteriser(ClassImposteriser.INSTANCE);}};
+    Mockery context = new Mockery(){{setImposteriser(ByteBuddyClassImposteriser.INSTANCE);}};
 
     Message msg;
     Message msg2;


### PR DESCRIPTION
## Summary

- Deletes the hand-authored `src/main/resources/META-INF/MANIFEST.MF` whose `Class-Path` listed dependencies at very old versions (guava 11.0.1, jmock 2.5.1, args4j 2.0.8) and referenced jars no longer in the project
- The `application` plugin manages the classpath via generated startup scripts so the static `Class-Path` was never used; Gradle generates a correct minimal manifest at build time
- Updates the Java toolchain in `build.gradle` from 11 → 17 to match `.tool-versions` and the CI workflow

## Test plan

- [ ] CI build passes
- [ ] `./gradlew installDist` produces correct distribution with working startup scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)