### PR TITLE
Replace joda-time with java.time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ dependencies {
     implementation group: 'com.google.guava', name: 'guava', version: '33.6.0-jre'
     implementation group: 'javax.activation', name: 'javax.activation-api', version: '1.2.0'
     implementation group: 'com.sun.mail', name: 'jakarta.mail', version: '2.0.2'
-    implementation group: 'joda-time', name: 'joda-time', version: '2.14.2'
     implementation group: 'org.mozilla', name: 'rhino', version: '1.9.1'
     implementation group: 'com.google.code.findbugs', name: 'jsr305', version: '3.0.2'
     implementation 'org.ethelred:ethelred_util:1.0.1'

--- a/src/main/java/org/ethelred/mymailtool2/DefaultContext.java
+++ b/src/main/java/org/ethelred/mymailtool2/DefaultContext.java
@@ -5,11 +5,10 @@ import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import org.ethelred.mymailtool2.matcher.AgeMatcher;
 import org.ethelred.util.ClockFactory;
-import org.joda.time.DateTime;
-import org.joda.time.Days;
-import org.joda.time.Period;
-import org.joda.time.ReadablePeriod;
-import org.joda.time.format.PeriodFormat;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.annotation.CheckForNull;
 import jakarta.mail.Authenticator;
@@ -39,8 +38,7 @@ public class DefaultContext implements MailToolContext
 
     protected Map<String, Folder> folderCache;
 
-    protected static final ReadablePeriod DEFAULT_MIN_AGE = Days.days(30);
-    private DateTime ageCompare;
+    protected static final Duration DEFAULT_MIN_AGE = Duration.ofDays(30);
     private long startTime = ClockFactory.getClock().currentTimeMillis();
     private long timeLimit = -1;
     private int operationLimit = -1;
@@ -143,12 +141,33 @@ public class DefaultContext implements MailToolContext
         long newTimeLimit = 0;
         if (! Strings.isNullOrEmpty(timeLimitSpec))
         {
-            Period p = PeriodFormat.getDefault().parsePeriod(timeLimitSpec);
-            newTimeLimit = p.toStandardDuration().getMillis();
+            newTimeLimit = parseDuration(timeLimitSpec).toMillis();
         }
         LOGGER.debug("Time limit {}ms", newTimeLimit);
         timeLimit = newTimeLimit;
         return timeLimit;
+    }
+
+    private static final Pattern DURATION_PART = Pattern.compile("(\\d+)\\s*(second|minute|hour|day|week)s?", Pattern.CASE_INSENSITIVE);
+
+    private static Duration parseDuration(String spec) {
+        try {
+            return Duration.parse(spec);
+        } catch (DateTimeParseException ignored) {}
+        Matcher m = DURATION_PART.matcher(spec);
+        Duration total = Duration.ZERO;
+        while (m.find()) {
+            long n = Long.parseLong(m.group(1));
+            total = total.plus(switch (m.group(2).toLowerCase()) {
+                case "second" -> Duration.ofSeconds(n);
+                case "minute" -> Duration.ofMinutes(n);
+                case "hour" -> Duration.ofHours(n);
+                case "day" -> Duration.ofDays(n);
+                case "week" -> Duration.ofDays(n * 7);
+                default -> Duration.ZERO;
+            });
+        }
+        return total;
     }
 
     @Override

--- a/src/main/java/org/ethelred/mymailtool2/SplitOperation.java
+++ b/src/main/java/org/ethelred/mymailtool2/SplitOperation.java
@@ -6,9 +6,10 @@ import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.joda.time.LocalDate;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.DateTimeFormatterBuilder;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 /**
  *
@@ -19,15 +20,14 @@ public class SplitOperation implements MessageOperation
 
     private static final Logger LOGGER = LogManager.getLogger();
 
-    private static final DateTimeFormatter monthPart = new DateTimeFormatterBuilder().appendMonthOfYear(2).appendLiteral('-').appendMonthOfYearShortText().appendLiteral(
-            '-').appendYear(4, 4).toFormatter();
+    private static final DateTimeFormatter monthPart = DateTimeFormatter.ofPattern("MM-MMM-yyyy", Locale.ENGLISH);
 
     @Override
     public boolean apply(MailToolContext context, Message m)
     {
         try
         {
-            LocalDate received = new LocalDate(m.getReceivedDate());
+            LocalDate received = m.getReceivedDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
             Folder startingFolder = m.getFolder();
             Folder moveTo = context.getFolder(getSubFolderName(startingFolder, received));
             startingFolder.copyMessages(new Message[]{m}, moveTo);
@@ -58,7 +58,7 @@ public class SplitOperation implements MessageOperation
     {
         char sep = folder.getSeparator();
         String year = String.valueOf(received.getYear());
-        String month = monthPart.print(received);
+        String month = monthPart.format(received);
         return folder.getFullName() + sep + year + sep + month;
     }
 }

--- a/src/main/java/org/ethelred/mymailtool2/matcher/AgeMatcher.java
+++ b/src/main/java/org/ethelred/mymailtool2/matcher/AgeMatcher.java
@@ -6,27 +6,51 @@ import jakarta.mail.MessagingException;
 import org.ethelred.mymailtool2.ShortcutFolderScanException;
 import org.ethelred.mymailtool2.Task;
 import org.ethelred.util.ClockFactory;
-import org.joda.time.DateTime;
-import org.joda.time.format.PeriodFormat;
-
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
 import java.util.function.Predicate;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * matches against the age of the message
  */
 public class AgeMatcher implements Predicate<Message>
 {
+    private static final Pattern DURATION_PART = Pattern.compile("(\\d+)\\s*(second|minute|hour|day|week)s?", Pattern.CASE_INSENSITIVE);
+
     private final boolean older;
-    private final DateTime comparisonTime;
+    private final Instant comparisonTime;
     private final Task task;
 
     public AgeMatcher(String periodSpec, boolean older, @CheckForNull Task t)
     {
         this.older = older;
-        this.comparisonTime = new DateTime(ClockFactory.getClock().currentTimeMillis()).minus(PeriodFormat.getDefault().parsePeriod(periodSpec));
+        this.comparisonTime = Instant.ofEpochMilli(ClockFactory.getClock().currentTimeMillis()).minus(parseDuration(periodSpec));
         this.task = t;
+    }
+
+    private static Duration parseDuration(String spec) {
+        try {
+            return Duration.parse(spec);
+        } catch (DateTimeParseException ignored) {}
+        Matcher m = DURATION_PART.matcher(spec);
+        Duration total = Duration.ZERO;
+        while (m.find()) {
+            long n = Long.parseLong(m.group(1));
+            total = total.plus(switch (m.group(2).toLowerCase()) {
+                case "second" -> Duration.ofSeconds(n);
+                case "minute" -> Duration.ofMinutes(n);
+                case "hour" -> Duration.ofHours(n);
+                case "day" -> Duration.ofDays(n);
+                case "week" -> Duration.ofDays(n * 7);
+                default -> Duration.ZERO;
+            });
+        }
+        return total;
     }
 
     @Override
@@ -39,7 +63,7 @@ public class AgeMatcher implements Predicate<Message>
 
         try
         {
-            DateTime received = new DateTime(message.getReceivedDate());
+            Instant received = message.getReceivedDate().toInstant();
 
             if (task == null)
             {

--- a/src/test/java/org/ethelred/mymailtool2/MainTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/MainTest.java
@@ -4,8 +4,8 @@ import org.ethelred.util.ClockFactory;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
-import org.joda.time.DateMidnight;
-import org.joda.time.DateTime;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.junit.Test;
 
 import jakarta.mail.Message;
@@ -29,7 +29,7 @@ public class MainTest
     {
         final MailToolConfiguration conf = my.mock(MailToolConfiguration.class);
 
-        ClockFactory.setClock(new DateMidnight(2014, 1, 1).getMillis());
+        ClockFactory.setClock(LocalDate.of(2014, 1, 1).atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli());
         my.checking(new Expectations(){{
             exactly(2).of(conf).getOperationLimit(); will(returnValue(3));
             exactly(1).of(conf).getTimeLimit(); will(returnValue("50 days"));

--- a/src/test/java/org/ethelred/mymailtool2/MessageOperationsTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/MessageOperationsTest.java
@@ -10,7 +10,8 @@ import jakarta.mail.MessagingException;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.imposters.ByteBuddyClassImposteriser;
-import org.joda.time.LocalDate;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -100,7 +101,7 @@ public class MessageOperationsTest
                 oneOf(msg).getFolder(); will(returnValue(startingFolder));
                 oneOf(startingFolder).getSeparator(); will(returnValue('.'));
                 exactly(2).of(startingFolder).getFullName(); will(returnValue("folder"));
-                oneOf(msg).getReceivedDate(); will(returnValue(new LocalDate(2012, 4, 8).toDate()));
+                oneOf(msg).getReceivedDate(); will(returnValue(Date.from(LocalDate.of(2012, 4, 8).atStartOfDay(ZoneId.systemDefault()).toInstant())));
                 oneOf(mailContext).getFolder("folder.2012.04-Apr-2012"); will(returnValue(moveTo));
                 //allowing(moveTo).getFullName(); will(returnValue("folder.04-Apr-2012"));
                 oneOf(startingFolder).copyMessages(with(hasItemInArray(msg)), with(equal(moveTo)));


### PR DESCRIPTION
## Summary

- Migrates all joda-time usage to `java.time` equivalents (`LocalDate`, `Instant`, `Duration`, `DateTimeFormatter`) across `AgeMatcher`, `DefaultContext`, and `SplitOperation`
- Adds a `parseDuration()` helper to replace `PeriodFormat.parsePeriod()`, supporting English "N days/hours/..." strings and ISO-8601 as a fallback
- Updates test files (`MainTest`, `MessageOperationsTest`) to use `java.time` for date construction
- Removes the `joda-time` dependency from `build.gradle`

## Test plan

- [x] All existing tests pass (`./gradlew test`)
- [ ] Manual smoke test: verify split/age-based mail operations behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)