### PR TITLE
Fix MoveOperation log printing lambda toString() instead of message summary

### DIFF
--- a/src/main/java/org/ethelred/mymailtool2/MoveOperation.java
+++ b/src/main/java/org/ethelred/mymailtool2/MoveOperation.java
@@ -30,7 +30,7 @@ public class MoveOperation implements MessageOperation
             Folder moveTo = context.getFolder(moveToFolderName);
             startingFolder.copyMessages(new Message[]{m}, moveTo);
             m.setFlag(Flags.Flag.DELETED, true);
-            LOGGER.info("Move message {} from {} to {}", MailUtil.supplyString(m), startingFolder.getFullName(), moveTo.getFullName());
+            LOGGER.info("Move message {} from {} to {}", MailUtil.supplyString(m), startingFolder::getFullName, moveTo::getFullName);
             return true;
         }
         catch (MessagingException e)


### PR DESCRIPTION
## Summary
- `MoveOperation` logged move messages like `Move message org.ethelred.mymailtool2.MailUtil$$Lambda/...@...` instead of the intended date/subject summary
- Cause: mixing a `Supplier<String>` arg with plain `String` args made log4j2 resolve the `info(String, Object...)` overload instead of `info(String, Supplier<?>...)`, so the lazy message supplier was never invoked and its `toString()` was printed instead
- Fix: pass the folder names as method references too, matching the working pattern already used in `SplitOperation`

## Test plan
- [x] `./gradlew compileJava` succeeds
- [ ] Run a move operation against a mailbox and confirm the log line now shows the formatted date/subject instead of a `MailUtil$$Lambda/...@...` reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)