### PR TITLE
Fix remaining log4j2 Supplier overload-resolution traps

### DIFF
--- a/src/main/java/org/ethelred/mymailtool2/ApplyMatchOperationsTask.java
+++ b/src/main/java/org/ethelred/mymailtool2/ApplyMatchOperationsTask.java
@@ -190,7 +190,7 @@ public class ApplyMatchOperationsTask extends TaskBase
     @Override
     protected void runMessage(Folder f, Message m) throws MessagingException
     {
-        LOGGER.debug("Checking {}", MailUtil.supplyString(m));
+        LOGGER.debug("Checking {}", () -> MailUtil.supplyString(m).get());
         context.countMessage();
         // match/operation
         int ruleCount = 0;

--- a/src/main/java/org/ethelred/mymailtool2/DeleteOperation.java
+++ b/src/main/java/org/ethelred/mymailtool2/DeleteOperation.java
@@ -21,7 +21,7 @@ public class DeleteOperation implements MessageOperation
         try
         {
             m.setFlag(Flags.Flag.DELETED, true);
-            LOGGER.info("Delete message {}", MailUtil.supplyString(m));
+            LOGGER.info("Delete message {}", () -> MailUtil.supplyString(m).get());
             return true;
         }
         catch (MessagingException e)

--- a/src/main/java/org/ethelred/mymailtool2/MailUtil.java
+++ b/src/main/java/org/ethelred/mymailtool2/MailUtil.java
@@ -14,6 +14,14 @@ public final class MailUtil
      */
     private MailUtil() {}
 
+    /**
+     * Call sites must pass the result as (or alongside) a lambda/method-reference literal,
+     * e.g. {@code () -> MailUtil.supplyString(m).get()}. Passing this call's result directly
+     * makes log4j2 pick the fixed-arity {@code info(String, Object)} overload instead of the
+     * lazy {@code info(String, Supplier<?>...)} one, since a plain Supplier-typed expression
+     * (unlike a lambda literal) is still Object-compatible — this silently logs the Supplier's
+     * own toString() instead of invoking it.
+     */
     public static Supplier<String> supplyString(Message m) {
         return () -> {
             try {

--- a/src/main/java/org/ethelred/mymailtool2/MatchOperation.java
+++ b/src/main/java/org/ethelred/mymailtool2/MatchOperation.java
@@ -29,7 +29,7 @@ public class MatchOperation
     {
         if (match.test(m) && operation.apply(ctx, m))
         {
-            LOGGER.debug("Matched {} and applied {} to message {}", match, operation, m);
+            LOGGER.debug("Matched {} and applied {} to message {}", () -> match, () -> operation, MailUtil.supplyString(m));
             ctx.countOperation();
             return operation.finishApplying();
         }


### PR DESCRIPTION
## Summary
- `DeleteOperation` and `ApplyMatchOperationsTask#runMessage` still printed a lambda `toString()` instead of the message summary, same family of bug as #133 but with a different root cause: a **single** `Supplier`-typed argument (or all-plain-object arguments) doesn't disqualify log4j2's fixed-arity `info(String, Object)`/`info(String, Object, Object, ...)` overloads, so `.get()` is never invoked. Only an actual lambda/method-reference *literal* at the call site forces the lazy `Supplier<?>...` overload (verified with a standalone repro).
- `MatchOperation` had a related bug: it logged the raw `Message` object rather than `MailUtil.supplyString(m)`.
- Fixed all three by wrapping the relevant arguments in literal lambdas, and documented the gotcha on `MailUtil.supplyString` for future call sites.

## Test plan
- [x] `./gradlew compileJava` succeeds
- [x] Standalone repro confirms plain `Supplier` arg → wrong overload → lambda toString printed; literal lambda arg → correct overload → lazy value printed
- [ ] Run delete/match operations against a mailbox and confirm log output shows the formatted date/subject instead of a `Lambda/...@...` reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)