### PR TITLE
Add JaCoCo coverage reporting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 plugins {
     id 'application'
+    id 'jacoco'
     id("org.openrewrite.rewrite") version("7.37.0")
+}
+
+jacoco {
+    toolVersion = '0.8.12'
 }
 
 repositories {
@@ -41,6 +46,18 @@ dependencies {
     rewrite("org.openrewrite.recipe:rewrite-logging-frameworks:latest.release")
     rewrite("org.openrewrite.recipe:rewrite-migrate-java:3.40.0")
     rewrite('org.apache.logging.log4j:log4j-api:2.26.1')
+}
+
+test {
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+    }
 }
 
 task install {


### PR DESCRIPTION
## Summary
- Adds the `jacoco` Gradle plugin (pinned to 0.8.12) to `build.gradle`
- `./gradlew test` now finalizes with `jacocoTestReport`, generating HTML and XML coverage reports under `build/reports/jacoco/test/`
- No coverage tooling existed previously, so there was no way to measure real line/branch coverage

## Test plan
- [x] Ran `./gradlew clean test` — build succeeded
- [x] Confirmed `build/reports/jacoco/test/html/index.html` and `jacocoTestReport.xml` are generated
- [x] Spot-checked report contents (overall ~62% line coverage, ~52% branch coverage; several classes like `SearchTask`, `FlagOperation`, matchers at 0%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)