### PR TITLE
Add fuller JS test fixture covering isOlderThan, includeSubFolders, and()

### DIFF
--- a/src/test/java/org/ethelred/mymailtool2/javascript/JavascriptConfigurationTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/javascript/JavascriptConfigurationTest.java
@@ -2,6 +2,7 @@ package org.ethelred.mymailtool2.javascript;
 
 import java.io.File;
 import java.net.URL;
+import java.text.SimpleDateFormat;
 
 import org.ethelred.mymailtool2.ApplyMatchOperationsTask;
 import org.ethelred.mymailtool2.FileConfigurationHandler;
@@ -11,6 +12,7 @@ import org.ethelred.mymailtool2.Task;
 import org.ethelred.mymailtool2.mock.MockData;
 import org.ethelred.mymailtool2.mock.MockDefaultConfiguration;
 import org.ethelred.mymailtool2.mock.MockMessage;
+import org.ethelred.util.ClockFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +27,7 @@ public class JavascriptConfigurationTest
     public void cleanup()
     {
         MockData.clear();
+        ClockFactory.reset();
     }
 
 
@@ -120,5 +123,46 @@ public class JavascriptConfigurationTest
 
 
         assertThat(data.folderSize("Inbox")).isEqualTo(1);
+    }
+
+    @Test
+    public void testFullerConfig() throws Exception
+    {
+        ClockFactory.setClock(new SimpleDateFormat("yyyy-MM-dd").parse("2024-01-10").getTime());
+
+        MockDefaultConfiguration conf = new MockDefaultConfiguration();
+        conf.addFileHandler(new JavascriptFileConfigurationHandler());
+        conf.addFile(this.getClass().getResource("fuller.js").getFile());
+
+        MockData data = MockData.getInstance();
+        data.addFolder("Inbox");
+        data.addFolder("old-messages");
+        data.addFolder("Currency");
+
+        // deleted by the spamSenders matcherList() rule
+        data.addMessage("Inbox", MockMessage.create("2024-01-09", "Fake Spam Co <spam1@example.com>", "Hello"));
+        // older than 4 days: moved to old-messages
+        data.addMessage("Inbox", MockMessage.create("2024-01-01", "legit@example.com", "Old news"));
+        // not old, not spam, not currency: stays in Inbox
+        data.addMessage("Inbox", MockMessage.create("2024-01-09", "legit@example.com", "Recent news"));
+        // matches both isFrom() and matchesSubject(): moved to Currency by the and() rule
+        data.addMessage("Inbox", MockMessage.create("2024-01-09", "Universal Currency Converter <ucc@example.com>", "Currency Update for today"));
+        // matches isFrom() only, not the subject: and() rule must not match, stays in Inbox
+        data.addMessage("Inbox", MockMessage.create("2024-01-09", "Universal Currency Converter <ucc2@example.com>", "Random subject"));
+        // pre-existing old-messages entry, deleted via the includeSubFolders() spamSenders rule
+        data.addMessage("old-messages", MockMessage.create("2023-01-01", "Another Spammer <spam3@example.com>", "junk"));
+
+        assertThat(data.folderSize("Inbox")).isEqualTo(5);
+        assertThat(data.folderSize("old-messages")).isEqualTo(1);
+        assertThat(data.folderSize("Currency")).isEqualTo(0);
+
+        Main main = new Main();
+        main.setDefaultConfiguration(conf);
+        main.init(new String[]{});
+        main.run();
+
+        assertThat(data.folderSize("Inbox")).isEqualTo(2);
+        assertThat(data.folderSize("old-messages")).isEqualTo(1);
+        assertThat(data.folderSize("Currency")).isEqualTo(1);
     }
 }

--- a/src/test/resources/org/ethelred/mymailtool2/javascript/fuller.js
+++ b/src/test/resources/org/ethelred/mymailtool2/javascript/fuller.js
@@ -1,0 +1,27 @@
+config({
+    mail: {
+        store: {
+            protocol: "imap"
+        },
+        user: "edward",
+        host: "mail.example.com",
+        port: 143,
+        imap: {starttls: {enable: true}}
+    },
+    password: "xxxxxx",
+    minage: "1 month",
+    operations: 300
+});
+
+function matcherList(input) {
+    return input.split(/,\s*/).map(function(s){return ".*" + s + ".*";});
+}
+
+var spamSenders = matcherList("Fake Spam Co, Another Spammer");
+
+deleteFrom("Inbox").ifIt(isFrom(spamSenders));
+deleteFrom("old-messages").ifIt(isFrom(spamSenders)).includeSubFolders();
+
+move("Inbox").to("old-messages").ifIt(isOlderThan("4 days"));
+
+move("Inbox").to("Currency").ifIt(isFrom(".*Currency Converter.*")).and(matchesSubject(".*Currency Update.*"));


### PR DESCRIPTION
## Summary
- Add `src/test/resources/org/ethelred/mymailtool2/javascript/fuller.js`, a sanitized fixture modelled on a real `.oamailrc.js` config, covering DSL features not exercised by the existing fixtures: a `matcherList()`-style regex-generating helper, `isFrom()` with a single regex string, `isOlderThan()`, `.includeSubFolders()`, and `.and()` predicate chaining.
- Add `testFullerConfig()` to `JavascriptConfigurationTest`, using `ClockFactory.setClock(...)` to pin "now" so the age-based assertions are deterministic, and asserting deletions, age-based moves, and the AND-combined currency rule via mock folder sizes.

## Test plan
- [x] `./gradlew test --tests '*JavascriptConfigurationTest*'` passes (all 4 tests, including the new one)
- [x] Verified `fuller.js` contains no real personal data (grepped for the real domain/addresses/password from the source config)

Note: while writing this, I found `AgeMatcher`'s duration parser only recognizes `second|minute|hour|day|week` — a spec like `"1 month"` silently parses as zero duration. The new fixture uses `"4 days"` to get real test coverage; the parsing gap itself is a separate, pre-existing issue not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)