### PR TITLE
Fix AgeMatcher duration parsing for month/year units

### DIFF
--- a/src/main/java/org/ethelred/mymailtool2/matcher/AgeMatcher.java
+++ b/src/main/java/org/ethelred/mymailtool2/matcher/AgeMatcher.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
  */
 public class AgeMatcher implements Predicate<Message>
 {
-    private static final Pattern DURATION_PART = Pattern.compile("(\\d+)\\s*(second|minute|hour|day|week)s?", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DURATION_PART = Pattern.compile("(\\d+)\\s*(second|minute|hour|day|week|month|year)s?", Pattern.CASE_INSENSITIVE);
 
     private final boolean older;
     private final Instant comparisonTime;
@@ -39,7 +39,9 @@ public class AgeMatcher implements Predicate<Message>
         } catch (DateTimeParseException ignored) {}
         Matcher m = DURATION_PART.matcher(spec);
         Duration total = Duration.ZERO;
+        boolean matchedAny = false;
         while (m.find()) {
+            matchedAny = true;
             long n = Long.parseLong(m.group(1));
             total = total.plus(switch (m.group(2).toLowerCase()) {
                 case "second" -> Duration.ofSeconds(n);
@@ -47,8 +49,13 @@ public class AgeMatcher implements Predicate<Message>
                 case "hour" -> Duration.ofHours(n);
                 case "day" -> Duration.ofDays(n);
                 case "week" -> Duration.ofDays(n * 7);
+                case "month" -> Duration.ofDays(n * 30);
+                case "year" -> Duration.ofDays(n * 365);
                 default -> Duration.ZERO;
             });
+        }
+        if (!matchedAny) {
+            throw new IllegalArgumentException("Unrecognized duration: '" + spec + "'");
         }
         return total;
     }

--- a/src/test/java/org/ethelred/mymailtool2/matcher/AgeMatcherTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/matcher/AgeMatcherTest.java
@@ -1,0 +1,100 @@
+package org.ethelred.mymailtool2.matcher;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import org.ethelred.util.ClockFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.function.Predicate;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * test age-based matching, in particular duration unit parsing
+ */
+public class AgeMatcherTest
+{
+    private static final Instant FIXED_NOW = Instant.parse("2024-01-10T00:00:00Z");
+
+    @AfterEach
+    public void resetClock()
+    {
+        ClockFactory.reset();
+    }
+
+    @Test
+    public void oneMonthIsNotSatisfiedByATenDayOldMessage() throws MessagingException
+    {
+        ClockFactory.setClock(FIXED_NOW.toEpochMilli());
+        Message msg = mock(Message.class);
+        when(msg.getReceivedDate()).thenReturn(Date.from(FIXED_NOW.minus(Duration.ofDays(10))));
+
+        Predicate<Message> matcher = new AgeMatcher("1 month", true, null);
+
+        assertThat(matcher.test(msg)).isFalse();
+    }
+
+    @Test
+    public void oneMonthIsSatisfiedByAFortyDayOldMessage() throws MessagingException
+    {
+        ClockFactory.setClock(FIXED_NOW.toEpochMilli());
+        Message msg = mock(Message.class);
+        when(msg.getReceivedDate()).thenReturn(Date.from(FIXED_NOW.minus(Duration.ofDays(40))));
+
+        Predicate<Message> matcher = new AgeMatcher("1 month", true, null);
+
+        assertThat(matcher.test(msg)).isTrue();
+    }
+
+    @Test
+    public void oneYearIsNotSatisfiedByASixMonthOldMessage() throws MessagingException
+    {
+        ClockFactory.setClock(FIXED_NOW.toEpochMilli());
+        Message msg = mock(Message.class);
+        when(msg.getReceivedDate()).thenReturn(Date.from(FIXED_NOW.minus(Duration.ofDays(180))));
+
+        Predicate<Message> matcher = new AgeMatcher("1 year", true, null);
+
+        assertThat(matcher.test(msg)).isFalse();
+    }
+
+    @Test
+    public void oneYearIsSatisfiedByAThirteenMonthOldMessage() throws MessagingException
+    {
+        ClockFactory.setClock(FIXED_NOW.toEpochMilli());
+        Message msg = mock(Message.class);
+        when(msg.getReceivedDate()).thenReturn(Date.from(FIXED_NOW.minus(Duration.ofDays(395))));
+
+        Predicate<Message> matcher = new AgeMatcher("1 year", true, null);
+
+        assertThat(matcher.test(msg)).isTrue();
+    }
+
+    @Test
+    public void pluralMonthsAreParsed() throws MessagingException
+    {
+        ClockFactory.setClock(FIXED_NOW.toEpochMilli());
+        Message msg = mock(Message.class);
+        when(msg.getReceivedDate()).thenReturn(Date.from(FIXED_NOW.minus(Duration.ofDays(70))));
+
+        Predicate<Message> matcher = new AgeMatcher("2 months", true, null);
+
+        assertThat(matcher.test(msg)).isTrue();
+    }
+
+    @Test
+    public void unrecognizedDurationUnitThrowsWithAClearMessage()
+    {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> new AgeMatcher("1 fortnight", true, null));
+
+        assertThat(e).hasMessageThat().contains("1 fortnight");
+    }
+}

--- a/src/test/resources/org/ethelred/mymailtool2/javascript/fuller.js
+++ b/src/test/resources/org/ethelred/mymailtool2/javascript/fuller.js
@@ -9,7 +9,7 @@ config({
         imap: {starttls: {enable: true}}
     },
     password: "xxxxxx",
-    minage: "1 month",
+    minage: "1 second",
     operations: 300
 });
 


### PR DESCRIPTION
## Summary
- `AgeMatcher`'s duration parser only recognized `second|minute|hour|day|week`. A spec like `"1 month"` (used by the real `.oamailrc.js` and by `fuller.js`'s `minage`) silently matched nothing and fell back to a zero-length duration, making `isOlderThan("1 month")` equivalent to "older than now".
- Added `month` (30 days) and `year` (365 days) to the recognized units.
- Unrecognized specs (e.g. `"1 fortnight"`) now throw `IllegalArgumentException` naming the bad input, instead of silently defaulting to zero.
- Added `AgeMatcherTest` (new), covering month/year thresholds, plurals, and the new exception — written and verified failing before the fix, per TDD.
- `fuller.js`'s `minage` changed from `"1 month"` to `"1 second"`: `minage` is ANDed in front of every rule via `ApplyMatchOperationsTask`, and was previously a silent no-op. With parsing fixed it started genuinely filtering out that fixture's short-lived test dates, which isn't what the fixture is testing.

## Test plan
- [x] `./gradlew test` — all 64 tests pass
- [x] Watched the new `AgeMatcherTest` fail before implementing the fix (RED), then pass (GREEN)

## Note
While debugging, I found `AgeMatcher`'s scan-shortcut optimization (for `isOlderThan`/`isNewerThan`) can abort an entire folder scan early when combined with other rules on the same folder — a pre-existing behavior of `ApplyMatchOperationsTask`, not touched by this PR, but worth being aware of if age-based and other rules are combined against the same folder in a real config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)