### PR TITLE
Migrate toolchain from Java 17 to Java 26

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v7
-    - name: Set up JDK 17
+    - name: Set up JDK 26
       uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '26'
         distribution: 'temurin'
         cache: 'gradle'
     - name: Grant execute permission for gradlew

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java temurin-17.0.20+8
+java temurin-26.0.2+10

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(26)
     }
 }
 


### PR DESCRIPTION
## Summary
- Bump `.tool-versions`, the Gradle toolchain (`JavaLanguageVersion.of(26)`), and the CI `actions/setup-java` step from Java 17 to Java 26 (Temurin)
- Verified Gradle 9.6.1, JaCoCo 0.8.15, and Mockito's transitive ByteBuddy all work correctly on Java 26 — no dependency bumps required

## Test plan
- [x] `./gradlew clean build` succeeds under the Java 26 toolchain
- [x] Full test suite passes (62 tests, 0 failures/errors)
- [x] `jacocoTestReport` generates without instrumentation errors
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)