### PR TITLE
Add incremental UID-based scan cache for ApplyMatchOperationsTask

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ By default it will try and read `.mymailtoolrc.properties` in the user's home di
 
 To run, use the `bin/mymailtool2` script. Pass `--help` to see command line options.
 
+Scan Cache
+----------
+Since it's meant to run from cron against the same mailboxes over and over, mymailtool remembers how far it got in each folder (a UID high-water-mark) and skips old messages it's already looked at on the next run. This is what keeps it fast even on a big mailbox with years of mail sitting in it.
+
+If your config files change, it forgets everything and does a full rescan next run. It also does a full rescan of a folder if the folder's UIDVALIDITY changes (e.g. it was rebuilt on the server). Pass `--no-scan-cache` (or set `mymailtool.noscancache`/`disableScanCache` in your config, depending on which config format you're using) to force a full rescan every time.
+
+Known limitation: once mymailtool has looked at a message and it didn't match anything, that's it - it won't look at that message again, even if something about it changes later (e.g. you go and flag it manually in your normal mail client, and you've got a rule that matches on flags). If you hit this, run once with `--no-scan-cache` to force a fresh look.
+
+The scan state is stored in a small properties file, by default somewhere sensible for your OS (e.g. `~/.cache/mymailtool/scan-state.properties` on Linux). You can point it elsewhere with `mymailtool.scanstatefile`/`scanStateFile` in your config.
+

--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ Known limitation: once mymailtool has looked at a message and it didn't match an
 
 The scan state is stored in a small properties file, by default somewhere sensible for your OS (e.g. `~/.cache/mymailtool/scan-state.properties` on Linux). You can point it elsewhere with `mymailtool.scanstatefile`/`scanStateFile` in your config.
 
+Renamed or removed folders leave a harmless stale entry in the state file; delete the file to clean up if you care.
+
+Don't run mymailtool2 concurrently against the same account - the scan-state file has no locking and concurrent writes could lose an update (harmless - worst case is an extra rescan - but not something to rely on).
+

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.26.1'
     implementation 'org.apache.logging.log4j:log4j-jul:2.26.1'
     implementation 'org.apache.logging.log4j:log4j-core:2.26.1'
+    implementation 'dev.dirs:directories:26'
 
     testImplementation platform('org.junit:junit-bom:6.1.2')
     testImplementation 'org.junit.jupiter:junit-jupiter'

--- a/src/main/java/org/ethelred/mymailtool2/ApplyMatchOperationsTask.java
+++ b/src/main/java/org/ethelred/mymailtool2/ApplyMatchOperationsTask.java
@@ -46,12 +46,12 @@ public class ApplyMatchOperationsTask extends TaskBase
     private final Random random = new Random();
 
     // Bridges the UID-range snapshot taken in readMessages() to the completion recording done
-    // in onFolderScanFinished() for the same folder's scan. -1 means "no valid UID snapshot for
-    // this folder's current scan". Safe as a plain mutable field ONLY because run() traverses
+    // in onFolderScanFinished() for the same folder's scan. Empty means "no valid UID snapshot
+    // for this folder's current scan". Safe as a plain mutable field ONLY because run() traverses
     // folders strictly sequentially, one at a time, in a single for loop -- never concurrently.
     // A future refactor introducing parallel folder traversal would need to make this
     // per-traversal state instead of a shared field.
-    private long scanEndUidExclusive = -1;
+    private OptionalLong scanEndUidExclusive = OptionalLong.empty();
 
     public boolean hasRules()
     {
@@ -238,20 +238,26 @@ public class ApplyMatchOperationsTask extends TaskBase
     @Override
     protected Iterable<? extends Message> readMessages(Folder f)
     {
-        scanEndUidExclusive = -1;
+        scanEndUidExclusive = OptionalLong.empty();
         try
         {
             OptionalLong resumeUid = context.getFolderScanCache().getResumeUid(f);
             if (resumeUid.isPresent())
             {
                 UidRangeMessageIterable it = new UidRangeMessageIterable(f, resumeUid.getAsLong());
-                scanEndUidExclusive = it.getEndUidExclusive();
+                scanEndUidExclusive = OptionalLong.of(it.getEndUidExclusive());
                 LOGGER.info("Resuming folder {} from UID {} (of {})", f.getFullName(), resumeUid.getAsLong(), scanEndUidExclusive);
                 return it;
             }
         }
-        catch (MessagingException e)
+        catch (MessagingException | RuntimeException e)
         {
+            // RuntimeException here covers UidRangeMessageIterable's constructor, which wraps
+            // any MessagingException from its own getUIDNext() snapshot call as an unchecked
+            // exception. Without catching it too, a transient IMAP failure at that specific call
+            // would propagate out of this method (and out of TaskBase.traverseFolder's
+            // ShortcutFolderScanException-only catch, and out of run()'s MessagingException/
+            // IOException-only catch), aborting the whole run instead of just this one folder.
             LOGGER.warn("Scan cache lookup failed for {}, falling back to full scan", f, e);
         }
         // Full scan path: still snapshot endUid if the folder supports it, so
@@ -261,11 +267,11 @@ public class ApplyMatchOperationsTask extends TaskBase
         {
             try
             {
-                scanEndUidExclusive = uf.getUIDNext();
+                scanEndUidExclusive = OptionalLong.of(uf.getUIDNext());
             }
             catch (MessagingException ignored)
             {
-                // leave scanEndUidExclusive at -1; onFolderScanFinished will skip recording
+                // leave scanEndUidExclusive empty; onFolderScanFinished will skip recording
             }
         }
         return super.readMessages(f);
@@ -274,7 +280,7 @@ public class ApplyMatchOperationsTask extends TaskBase
     @Override
     protected void onFolderScanFinished(Folder f, boolean completedFully, @CheckForNull Message lastConsidered)
     {
-        if (scanEndUidExclusive < 0)
+        if (scanEndUidExclusive.isEmpty())
         {
             // No valid UID snapshot was ever taken for this folder's scan (non-UIDFolder, or
             // getUIDNext() failed) -- nothing meaningful to persist.
@@ -282,7 +288,7 @@ public class ApplyMatchOperationsTask extends TaskBase
         }
         try
         {
-            context.getFolderScanCache().recordScanCompletion(f, scanEndUidExclusive, lastConsidered, completedFully);
+            context.getFolderScanCache().recordScanCompletion(f, scanEndUidExclusive.getAsLong(), lastConsidered, completedFully);
         }
         catch (MessagingException e)
         {

--- a/src/main/java/org/ethelred/mymailtool2/ApplyMatchOperationsTask.java
+++ b/src/main/java/org/ethelred/mymailtool2/ApplyMatchOperationsTask.java
@@ -8,18 +8,21 @@ import com.google.common.collect.Sets;
 import jakarta.mail.Folder;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
+import jakarta.mail.UIDFolder;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.ethelred.mymailtool2.matcher.AgeMatcher;
 import org.ethelred.mymailtool2.matcher.FolderMatcher;
 import org.ethelred.util.Predicates;
 
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.Random;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -41,6 +44,14 @@ public class ApplyMatchOperationsTask extends TaskBase
     Predicate<Message> defaultMinAgeDelegate;
     private  boolean deferredDefaultMinAge(Message message){return defaultMinAgeDelegate.test(message);}
     private final Random random = new Random();
+
+    // Bridges the UID-range snapshot taken in readMessages() to the completion recording done
+    // in onFolderScanFinished() for the same folder's scan. -1 means "no valid UID snapshot for
+    // this folder's current scan". Safe as a plain mutable field ONLY because run() traverses
+    // folders strictly sequentially, one at a time, in a single for loop -- never concurrently.
+    // A future refactor introducing parallel folder traversal would need to make this
+    // per-traversal state instead of a shared field.
+    private long scanEndUidExclusive = -1;
 
     public boolean hasRules()
     {
@@ -222,6 +233,61 @@ public class ApplyMatchOperationsTask extends TaskBase
     protected void status(Folder f)
     {
         LOGGER.info("Working on folder {}", f.getFullName());
+    }
+
+    @Override
+    protected Iterable<? extends Message> readMessages(Folder f)
+    {
+        scanEndUidExclusive = -1;
+        try
+        {
+            OptionalLong resumeUid = context.getFolderScanCache().getResumeUid(f);
+            if (resumeUid.isPresent())
+            {
+                UidRangeMessageIterable it = new UidRangeMessageIterable(f, resumeUid.getAsLong());
+                scanEndUidExclusive = it.getEndUidExclusive();
+                LOGGER.info("Resuming folder {} from UID {} (of {})", f.getFullName(), resumeUid.getAsLong(), scanEndUidExclusive);
+                return it;
+            }
+        }
+        catch (MessagingException e)
+        {
+            LOGGER.warn("Scan cache lookup failed for {}, falling back to full scan", f, e);
+        }
+        // Full scan path: still snapshot endUid if the folder supports it, so
+        // onFolderScanFinished can persist a fresh baseline even though this wasn't a
+        // resumed/incremental scan.
+        if (f instanceof UIDFolder uf)
+        {
+            try
+            {
+                scanEndUidExclusive = uf.getUIDNext();
+            }
+            catch (MessagingException ignored)
+            {
+                // leave scanEndUidExclusive at -1; onFolderScanFinished will skip recording
+            }
+        }
+        return super.readMessages(f);
+    }
+
+    @Override
+    protected void onFolderScanFinished(Folder f, boolean completedFully, @CheckForNull Message lastConsidered)
+    {
+        if (scanEndUidExclusive < 0)
+        {
+            // No valid UID snapshot was ever taken for this folder's scan (non-UIDFolder, or
+            // getUIDNext() failed) -- nothing meaningful to persist.
+            return;
+        }
+        try
+        {
+            context.getFolderScanCache().recordScanCompletion(f, scanEndUidExclusive, lastConsidered, completedFully);
+        }
+        catch (MessagingException e)
+        {
+            LOGGER.warn("Failed to persist scan state for {}", f, e);
+        }
     }
 
     public void addRule(String folder, Predicate<Message> matcher, List<Predicate<Message>> checkMatchers, MessageOperation operation, boolean includeSubFolders)

--- a/src/main/java/org/ethelred/mymailtool2/CommandLineConfiguration.java
+++ b/src/main/java/org/ethelred/mymailtool2/CommandLineConfiguration.java
@@ -66,6 +66,9 @@ class CommandLineConfiguration implements MailToolConfiguration
     @Option(name = "--random", usage = "Traverse folders in random order")
     private boolean random;
 
+    @Option(name = "--no-scan-cache", usage = "Disable incremental UID-based scan cache; always do a full rescan")
+    private boolean disableScanCache;
+
     @Override
     public int getChunkSize()
     {
@@ -307,6 +310,18 @@ class CommandLineConfiguration implements MailToolConfiguration
     public String getTimeLimit()
     {
         return runTimeLimit;
+    }
+
+    @Override
+    public String getScanStateFile()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean disableScanCache()
+    {
+        return disableScanCache;
     }
 
     @Override

--- a/src/main/java/org/ethelred/mymailtool2/CompositeConfiguration.java
+++ b/src/main/java/org/ethelred/mymailtool2/CompositeConfiguration.java
@@ -132,6 +132,25 @@ class CompositeConfiguration implements MailToolConfiguration
         return false;
     }
 
+    @Override
+    public String getScanStateFile()
+    {
+        return (String) first("getScanStateFile");
+    }
+
+    @Override
+    public boolean disableScanCache()
+    {
+        for (MailToolConfiguration subConf : configs)
+        {
+            if (subConf.disableScanCache())
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
     private class LazyCombinedIterable<T> implements Iterable<T>
     {
         private final Function<MailToolConfiguration, Iterable<T>> accessor;

--- a/src/main/java/org/ethelred/mymailtool2/ConfigFingerprint.java
+++ b/src/main/java/org/ethelred/mymailtool2/ConfigFingerprint.java
@@ -1,0 +1,50 @@
+package org.ethelred.mymailtool2;
+
+import com.google.common.hash.Hasher;
+import com.google.common.hash.Hashing;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+
+/**
+ * Computes a deterministic fingerprint over an ordered list of config files.
+ * <p>
+ * The fingerprint includes each file's normalized absolute path and whether it
+ * exists, in addition to its content. Hashing the path and existence flag - not
+ * just the content - means that adding or removing a config file from the
+ * resolved set (even one that does not exist on disk) changes the fingerprint,
+ * not just editing the content of files that happen to exist.
+ */
+public final class ConfigFingerprint
+{
+    private ConfigFingerprint()
+    {
+    }
+
+    /**
+     * Compute a fingerprint for the given files, iterated in the order provided.
+     *
+     * @param files the config files to fingerprint, in a deterministic order
+     * @return a hex-encoded SHA-256 based fingerprint
+     * @throws IOException if a file that exists cannot be read
+     */
+    public static String compute(List<File> files) throws IOException
+    {
+        Hasher hasher = Hashing.sha256().newHasher();
+        for (File file : files)
+        {
+            File normalized = file.getAbsoluteFile();
+            hasher.putString(normalized.toPath().normalize().toString(), StandardCharsets.UTF_8);
+            boolean exists = normalized.exists();
+            hasher.putByte((byte) (exists ? 1 : 0));
+            if (exists)
+            {
+                hasher.putBytes(Files.readAllBytes(normalized.toPath()));
+            }
+        }
+        return hasher.hash().toString();
+    }
+}

--- a/src/main/java/org/ethelred/mymailtool2/DefaultConfiguration.java
+++ b/src/main/java/org/ethelred/mymailtool2/DefaultConfiguration.java
@@ -1,6 +1,7 @@
 package org.ethelred.mymailtool2;
 
 import com.google.common.collect.ImmutableList;
+import dev.dirs.ProjectDirectories;
 import org.ethelred.mymailtool2.propertiesfile.PropertiesFileConfigurationHandler;
 
 import java.io.File;
@@ -92,7 +93,14 @@ class DefaultConfiguration implements MailToolConfiguration
     @Override
     public String getScanStateFile()
     {
-        return dev.dirs.ProjectDirectories.from("org", "ethelred", "mymailtool").cacheDir + File.separator + "scan-state.properties";
+        try
+        {
+            return ProjectDirectories.from("org", "ethelred", "mymailtool").cacheDir + File.separator + "scan-state.properties";
+        }
+        catch (Exception e)
+        {
+            return null;
+        }
     }
 
     @Override

--- a/src/main/java/org/ethelred/mymailtool2/DefaultConfiguration.java
+++ b/src/main/java/org/ethelred/mymailtool2/DefaultConfiguration.java
@@ -90,6 +90,18 @@ class DefaultConfiguration implements MailToolConfiguration
     }
 
     @Override
+    public String getScanStateFile()
+    {
+        return dev.dirs.ProjectDirectories.from("org", "ethelred", "mymailtool").cacheDir + File.separator + "scan-state.properties";
+    }
+
+    @Override
+    public boolean disableScanCache()
+    {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "DefaultConfiguration";
     }

--- a/src/main/java/org/ethelred/mymailtool2/DefaultContext.java
+++ b/src/main/java/org/ethelred/mymailtool2/DefaultContext.java
@@ -22,6 +22,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.io.Console;
+import java.io.File;
 import java.util.Map;
 import java.util.Properties;
 
@@ -44,13 +45,24 @@ public class DefaultContext implements MailToolContext
     private int operationLimit = -1;
     private volatile boolean shutdown;
     private final boolean verbose;
+    private final FolderScanCache folderScanCache;
 
     int messageCheckedCount;
 
     public DefaultContext(MailToolConfiguration config)
     {
+        this(config, null);
+    }
+
+    public DefaultContext(MailToolConfiguration config, @CheckForNull String configFingerprint)
+    {
         this.config = config;
         this.verbose = config.verbose();
+        String accountKey = config.getUser() + "@" + config.getMailProperties().getOrDefault(MailToolConfiguration.HOST, "");
+        String scanStateFilePath = config.getScanStateFile();
+        File stateFile = scanStateFilePath == null ? null : new File(scanStateFilePath);
+        boolean disabled = config.disableScanCache() || stateFile == null;
+        this.folderScanCache = new DefaultFolderScanCache(accountKey, stateFile, configFingerprint, disabled);
     }
 
     @Override
@@ -270,5 +282,11 @@ public class DefaultContext implements MailToolContext
     @Override
     public boolean randomTraversal() {
         return config.randomTraversal();
+    }
+
+    @Override
+    public FolderScanCache getFolderScanCache()
+    {
+        return folderScanCache;
     }
 }

--- a/src/main/java/org/ethelred/mymailtool2/DefaultContext.java
+++ b/src/main/java/org/ethelred/mymailtool2/DefaultContext.java
@@ -58,7 +58,11 @@ public class DefaultContext implements MailToolContext
     {
         this.config = config;
         this.verbose = config.verbose();
-        String accountKey = config.getUser() + "@" + config.getMailProperties().getOrDefault(MailToolConfiguration.HOST, "");
+        // A null user (e.g. some auth modes, or test configs) is tolerated: the cache just
+        // gets a stable-but-generic key in that case instead of a distinct per-account bucket,
+        // which is still functionally correct.
+        String user = config.getUser() == null ? "unknown" : config.getUser();
+        String accountKey = user + "@" + config.getMailProperties().getOrDefault(MailToolConfiguration.HOST, "");
         String scanStateFilePath = config.getScanStateFile();
         File stateFile = scanStateFilePath == null ? null : new File(scanStateFilePath);
         boolean disabled = config.disableScanCache() || stateFile == null;

--- a/src/main/java/org/ethelred/mymailtool2/DefaultFolderScanCache.java
+++ b/src/main/java/org/ethelred/mymailtool2/DefaultFolderScanCache.java
@@ -1,0 +1,109 @@
+package org.ethelred.mymailtool2;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.OptionalLong;
+
+import javax.annotation.CheckForNull;
+
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.UIDFolder;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Default {@link FolderScanCache} implementation, backed by a {@link ScanState}
+ * loaded once at construction time.
+ */
+public class DefaultFolderScanCache implements FolderScanCache
+{
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private final String accountKey;
+    @CheckForNull
+    private final File stateFile;
+    @CheckForNull
+    private final String currentFingerprint;
+    private final boolean disabled;
+    @CheckForNull
+    private final ScanState state;
+
+    public DefaultFolderScanCache(String accountKey, @CheckForNull File stateFile,
+                                   @CheckForNull String currentFingerprint, boolean disabled)
+    {
+        this.accountKey = accountKey;
+        this.stateFile = stateFile;
+        this.currentFingerprint = currentFingerprint;
+        this.disabled = disabled;
+        this.state = (disabled || stateFile == null) ? null : ScanState.loadOrEmpty(stateFile);
+    }
+
+    @Override
+    public OptionalLong getResumeUid(Folder folder) throws MessagingException
+    {
+        if (disabled || stateFile == null || currentFingerprint == null || !(folder instanceof UIDFolder))
+        {
+            return OptionalLong.empty();
+        }
+
+        String storedFingerprint = state.getConfigFingerprint();
+        if (storedFingerprint == null || !storedFingerprint.equals(currentFingerprint))
+        {
+            return OptionalLong.empty();
+        }
+
+        var stored = state.get(accountKey, folder.getFullName());
+        if (stored.isEmpty())
+        {
+            return OptionalLong.empty();
+        }
+
+        long currentUidValidity = ((UIDFolder) folder).getUIDValidity();
+        if (stored.get().uidValidity() != currentUidValidity)
+        {
+            return OptionalLong.empty();
+        }
+
+        return OptionalLong.of(stored.get().nextUid());
+    }
+
+    @Override
+    public void recordScanCompletion(Folder folder, long endUidExclusiveOfThisScan,
+                                      @CheckForNull Message lastConsidered, boolean completedFully) throws MessagingException
+    {
+        if (disabled || stateFile == null || !(folder instanceof UIDFolder))
+        {
+            return;
+        }
+
+        UIDFolder uidFolder = (UIDFolder) folder;
+        long nextUid;
+        if (completedFully)
+        {
+            nextUid = endUidExclusiveOfThisScan;
+        }
+        else if (lastConsidered != null)
+        {
+            nextUid = uidFolder.getUID(lastConsidered);
+        }
+        else
+        {
+            // Nothing new learned about this folder; leave any existing stored state untouched.
+            return;
+        }
+
+        state.put(accountKey, folder.getFullName(), new ScanState.FolderScanState(uidFolder.getUIDValidity(), nextUid));
+        state.setConfigFingerprint(currentFingerprint);
+        try
+        {
+            state.save(stateFile);
+        }
+        catch (IOException ex)
+        {
+            LOGGER.warn("Failed to save scan-state file {}, continuing without persisting this update", stateFile, ex);
+        }
+    }
+}

--- a/src/main/java/org/ethelred/mymailtool2/DefaultFolderScanCache.java
+++ b/src/main/java/org/ethelred/mymailtool2/DefaultFolderScanCache.java
@@ -28,7 +28,6 @@ public class DefaultFolderScanCache implements FolderScanCache
     @CheckForNull
     private final String currentFingerprint;
     private final boolean disabled;
-    @CheckForNull
     private final ScanState state;
 
     public DefaultFolderScanCache(String accountKey, @CheckForNull File stateFile,
@@ -38,13 +37,16 @@ public class DefaultFolderScanCache implements FolderScanCache
         this.stateFile = stateFile;
         this.currentFingerprint = currentFingerprint;
         this.disabled = disabled;
-        this.state = (disabled || stateFile == null) ? null : ScanState.loadOrEmpty(stateFile);
+        // Always non-null, even when unused (disabled or no stateFile): callers guard on those
+        // conditions independently before touching state, so there is no cross-field invariant
+        // to reconstruct here, and this branch never has anything to load in that case anyway.
+        this.state = (disabled || stateFile == null) ? new ScanState() : ScanState.loadOrEmpty(stateFile);
     }
 
     @Override
     public OptionalLong getResumeUid(Folder folder) throws MessagingException
     {
-        if (disabled || stateFile == null || currentFingerprint == null || !(folder instanceof UIDFolder))
+        if (disabled || stateFile == null || currentFingerprint == null || !(folder instanceof UIDFolder uidFolder))
         {
             return OptionalLong.empty();
         }
@@ -61,7 +63,7 @@ public class DefaultFolderScanCache implements FolderScanCache
             return OptionalLong.empty();
         }
 
-        long currentUidValidity = ((UIDFolder) folder).getUIDValidity();
+        long currentUidValidity = uidFolder.getUIDValidity();
         if (stored.get().uidValidity() != currentUidValidity)
         {
             return OptionalLong.empty();
@@ -74,12 +76,16 @@ public class DefaultFolderScanCache implements FolderScanCache
     public void recordScanCompletion(Folder folder, long endUidExclusiveOfThisScan,
                                       @CheckForNull Message lastConsidered, boolean completedFully) throws MessagingException
     {
-        if (disabled || stateFile == null || !(folder instanceof UIDFolder))
+        // Mirrors getResumeUid's treatment of a null fingerprint as "cache not usable this run":
+        // recording here would stamp a null fingerprint over any good one already on disk,
+        // which would make every future getResumeUid call see a mismatch and force a full scan
+        // even once a real fingerprint becomes available again. No-op instead and let a run
+        // with a working fingerprint record state normally.
+        if (disabled || stateFile == null || currentFingerprint == null || !(folder instanceof UIDFolder uidFolder))
         {
             return;
         }
 
-        UIDFolder uidFolder = (UIDFolder) folder;
         long nextUid;
         if (completedFully)
         {

--- a/src/main/java/org/ethelred/mymailtool2/FolderScanCache.java
+++ b/src/main/java/org/ethelred/mymailtool2/FolderScanCache.java
@@ -14,8 +14,15 @@ import jakarta.mail.MessagingException;
  * scan so future runs can benefit from it.
  * <p>
  * This is purely a decision-making layer on top of {@link ScanState}: it does
- * not iterate over messages itself (see {@code UidRangeMessageIterable}) and
- * it is not yet wired into any production task/context code.
+ * not iterate over messages itself (see {@code UidRangeMessageIterable}).
+ * <p>
+ * Known limitation: once a message has been fully considered by a scan and
+ * matched nothing, its UID falls behind the recorded resume point and it will
+ * be skipped by every subsequent scan, even if something about the message
+ * itself later changes in a way that would now make it match (e.g. a
+ * {@code hasFlag}-based rule, and the message is flagged afterwards via
+ * another client). Only a full rescan (e.g. {@code --no-scan-cache}, or any
+ * change that invalidates the config fingerprint) will reconsider it.
  */
 public interface FolderScanCache
 {

--- a/src/main/java/org/ethelred/mymailtool2/FolderScanCache.java
+++ b/src/main/java/org/ethelred/mymailtool2/FolderScanCache.java
@@ -1,0 +1,43 @@
+package org.ethelred.mymailtool2;
+
+import java.util.OptionalLong;
+
+import javax.annotation.CheckForNull;
+
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+
+/**
+ * Decides, for a given IMAP {@link Folder}, whether a scan can resume from a
+ * cached UID or must fall back to a full scan, and records the outcome of a
+ * scan so future runs can benefit from it.
+ * <p>
+ * This is purely a decision-making layer on top of {@link ScanState}: it does
+ * not iterate over messages itself (see {@code UidRangeMessageIterable}) and
+ * it is not yet wired into any production task/context code.
+ */
+public interface FolderScanCache
+{
+    /**
+     * Returns the UID to resume scanning from for {@code folder}, or
+     * {@link OptionalLong#empty()} if no usable cached resume point exists
+     * and a full scan should be performed instead.
+     */
+    OptionalLong getResumeUid(Folder folder) throws MessagingException;
+
+    /**
+     * Records the outcome of a scan of {@code folder}.
+     *
+     * @param endUidExclusiveOfThisScan the UID boundary (exclusive) that was snapshotted
+     *                                  before the scan began; used verbatim as the new resume
+     *                                  point when {@code completedFully} is {@code true}
+     * @param lastConsidered            the last message the scan looked at before stopping
+     *                                  short, or {@code null} if none was considered (e.g. an
+     *                                  exception before any message was read); may also be
+     *                                  {@code null} when {@code completedFully} is {@code true}
+     * @param completedFully            whether the scan covered the whole snapshotted range
+     */
+    void recordScanCompletion(Folder folder, long endUidExclusiveOfThisScan,
+                               @CheckForNull Message lastConsidered, boolean completedFully) throws MessagingException;
+}

--- a/src/main/java/org/ethelred/mymailtool2/MailToolConfiguration.java
+++ b/src/main/java/org/ethelred/mymailtool2/MailToolConfiguration.java
@@ -42,4 +42,8 @@ public interface MailToolConfiguration
     int getChunkSize();
 
     boolean randomTraversal();
+
+    String getScanStateFile();
+
+    boolean disableScanCache();
 }

--- a/src/main/java/org/ethelred/mymailtool2/MailToolContext.java
+++ b/src/main/java/org/ethelred/mymailtool2/MailToolContext.java
@@ -34,4 +34,6 @@ public interface MailToolContext
     int getChunkSize();
 
     boolean randomTraversal();
+
+    FolderScanCache getFolderScanCache();
 }

--- a/src/main/java/org/ethelred/mymailtool2/Main.java
+++ b/src/main/java/org/ethelred/mymailtool2/Main.java
@@ -10,8 +10,13 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
 
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 /**
  *
@@ -24,6 +29,9 @@ public class Main
 
     @VisibleForTesting
     MailToolConfiguration config;
+
+    @VisibleForTesting
+    String configFingerprint;
 
     private MailToolContext context;
     private volatile MailToolConfiguration defaultConfiguration;
@@ -51,6 +59,19 @@ public class Main
             for (String fileLocation : temp.getFileLocations())
             {
                 FileConfigurationHelper.loadFileConfiguration(temp, fileLocation);
+            }
+
+            List<File> configFiles = StreamSupport.stream(temp.getFileLocations().spliterator(), false)
+                    .map(File::new)
+                    .collect(Collectors.toList());
+            try
+            {
+                configFingerprint = ConfigFingerprint.compute(configFiles);
+            }
+            catch (IOException e)
+            {
+                LOGGER.warn("Failed to compute config fingerprint, scan cache will be disabled this run", e);
+                configFingerprint = null;
             }
 
             validateRequiredConfiguration(temp);
@@ -104,7 +125,7 @@ public class Main
                 setDebugLogging();
             }
 
-            context = new DefaultContext(config);
+            context = new DefaultContext(config, configFingerprint);
             context.connect();
 
             LOGGER.debug("About to get task from config {}", config);

--- a/src/main/java/org/ethelred/mymailtool2/ScanState.java
+++ b/src/main/java/org/ethelred/mymailtool2/ScanState.java
@@ -1,0 +1,165 @@
+package org.ethelred.mymailtool2;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Persisted incremental scan state: for each (account, IMAP folder) pair, the
+ * folder's {@code UIDVALIDITY} and the next UID to scan from, plus a single
+ * config fingerprint used elsewhere to decide whether this whole cache is
+ * still trustworthy.
+ * <p>
+ * This class purely loads/holds/saves that state; it makes no decisions about
+ * UID ranges or cache trust - see {@code FolderScanCache} for that.
+ */
+public class ScanState
+{
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String CONFIG_FINGERPRINT_KEY = "configFingerprint";
+    private static final Pattern FOLDER_ACCOUNT_KEY = Pattern.compile("^folder\\.(\\d+)\\.account$");
+    private static final String FILE_COMMENT = "mymailtool scan-state file - do not edit by hand";
+
+    /**
+     * Per-folder scan state: the folder's {@code UIDVALIDITY} at the time of the
+     * last scan, and the next UID to resume scanning from.
+     */
+    public record FolderScanState(long uidValidity, long nextUid)
+    {
+    }
+
+    private record FolderKey(String account, String folderFullName)
+    {
+    }
+
+    private final Map<FolderKey, FolderScanState> folderStates = new HashMap<>();
+
+    private String configFingerprint;
+
+    public String getConfigFingerprint()
+    {
+        return configFingerprint;
+    }
+
+    public void setConfigFingerprint(String configFingerprint)
+    {
+        this.configFingerprint = configFingerprint;
+    }
+
+    public Optional<FolderScanState> get(String account, String folderFullName)
+    {
+        return Optional.ofNullable(folderStates.get(new FolderKey(account, folderFullName)));
+    }
+
+    public void put(String account, String folderFullName, FolderScanState state)
+    {
+        folderStates.put(new FolderKey(account, folderFullName), state);
+    }
+
+    /**
+     * Load scan state from {@code file}. Never throws: a missing file yields a
+     * fresh empty state with no warning logged, while a file that exists but
+     * cannot be parsed yields a fresh empty state with a warning logged.
+     */
+    public static ScanState loadOrEmpty(File file)
+    {
+        if (!file.exists())
+        {
+            return new ScanState();
+        }
+        Properties properties = new Properties();
+        try (FileInputStream in = new FileInputStream(file))
+        {
+            properties.load(in);
+        }
+        catch (Exception ex)
+        {
+            LOGGER.warn("Failed to read scan-state file {}, ignoring and starting fresh", file, ex);
+            return new ScanState();
+        }
+        ScanState state = new ScanState();
+        state.configFingerprint = properties.getProperty(CONFIG_FINGERPRINT_KEY);
+        for (String key : properties.stringPropertyNames())
+        {
+            Matcher m = FOLDER_ACCOUNT_KEY.matcher(key);
+            if (!m.matches())
+            {
+                continue;
+            }
+            String index = m.group(1);
+            try
+            {
+                String account = requireProperty(properties, "folder." + index + ".account");
+                String name = requireProperty(properties, "folder." + index + ".name");
+                long uidValidity = Long.parseLong(requireProperty(properties, "folder." + index + ".uidValidity"));
+                long nextUid = Long.parseLong(requireProperty(properties, "folder." + index + ".nextUid"));
+                state.put(account, name, new FolderScanState(uidValidity, nextUid));
+            }
+            catch (RuntimeException ex)
+            {
+                LOGGER.warn("Skipping malformed scan-state folder entry at index {} in {}", index, file, ex);
+            }
+        }
+        return state;
+    }
+
+    private static String requireProperty(Properties properties, String key)
+    {
+        String value = properties.getProperty(key);
+        if (value == null)
+        {
+            throw new IllegalStateException("Missing required property " + key);
+        }
+        return value;
+    }
+
+    /**
+     * Save this state to {@code file}, atomically. Writes to a sibling temp file
+     * first, then renames it into place so a crash mid-write cannot leave a
+     * corrupt or partially-written target file.
+     */
+    public void save(File file) throws IOException
+    {
+        File parent = file.getParentFile();
+        if (parent != null)
+        {
+            parent.mkdirs();
+        }
+
+        Properties properties = new Properties();
+        if (configFingerprint != null)
+        {
+            properties.setProperty(CONFIG_FINGERPRINT_KEY, configFingerprint);
+        }
+        int index = 0;
+        for (Map.Entry<FolderKey, FolderScanState> entry : folderStates.entrySet())
+        {
+            String prefix = "folder." + index + ".";
+            properties.setProperty(prefix + "account", entry.getKey().account());
+            properties.setProperty(prefix + "name", entry.getKey().folderFullName());
+            properties.setProperty(prefix + "uidValidity", Long.toString(entry.getValue().uidValidity()));
+            properties.setProperty(prefix + "nextUid", Long.toString(entry.getValue().nextUid()));
+            index++;
+        }
+
+        File tmpFile = new File(parent, file.getName() + ".tmp");
+        try (FileOutputStream out = new FileOutputStream(tmpFile))
+        {
+            properties.store(out, FILE_COMMENT);
+        }
+        Files.move(tmpFile.toPath(), file.toPath(), StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+    }
+}

--- a/src/main/java/org/ethelred/mymailtool2/SystemPropertiesConfiguration.java
+++ b/src/main/java/org/ethelred/mymailtool2/SystemPropertiesConfiguration.java
@@ -94,6 +94,18 @@ class SystemPropertiesConfiguration implements MailToolConfiguration
     }
 
     @Override
+    public String getScanStateFile()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean disableScanCache()
+    {
+        return false;
+    }
+
+    @Override
     public String toString() {
         return "SystemPropertiesConfiguration";
     }

--- a/src/main/java/org/ethelred/mymailtool2/TaskBase.java
+++ b/src/main/java/org/ethelred/mymailtool2/TaskBase.java
@@ -1,5 +1,7 @@
 package org.ethelred.mymailtool2;
 
+import javax.annotation.CheckForNull;
+
 import jakarta.mail.Folder;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
@@ -43,18 +45,23 @@ abstract class TaskBase implements Task
         {
             f.open(openMode());
 
+            Message lastConsidered = null;
+            boolean completedFully = false;
             try
             {
                 for (Message m : readMessages(f))
                 {
+                    lastConsidered = m;
                     runMessage(f, m);
                 }
+                completedFully = true;
             }
             catch (ShortcutFolderScanException sc)
             {
                 LOGGER.info("Short cut on folder {}", f.getName());
             }
             finally {
+                onFolderScanFinished(f, completedFully, lastConsidered);
                 if ((openMode() & Folder.READ_WRITE) > 0) {
                     f.expunge();
                 }
@@ -69,6 +76,11 @@ abstract class TaskBase implements Task
                 traverseFolder(child, true, readMessages);
             }
         }
+    }
+
+    protected void onFolderScanFinished(Folder f, boolean completedFully, @CheckForNull Message lastConsidered)
+    {
+        // default no-op
     }
 
     protected abstract void runMessage(Folder f, Message m) throws MessagingException, IOException;

--- a/src/main/java/org/ethelred/mymailtool2/UidRangeMessageIterable.java
+++ b/src/main/java/org/ethelred/mymailtool2/UidRangeMessageIterable.java
@@ -1,0 +1,156 @@
+package org.ethelred.mymailtool2;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Iterator;
+import jakarta.mail.FetchProfile;
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.UIDFolder;
+
+/**
+ * Iterate, oldest-first, over the messages in a UID-capable folder whose UID falls in
+ * {@code [startUid, endUidExclusive)}, where {@code endUidExclusive} is a snapshot of
+ * {@link UIDFolder#getUIDNext()} taken once, up front, in the constructor.
+ *
+ * <p>Taking that snapshot before any fetch happens is the whole point of this class: it turns
+ * "how far this scan covers" into an unambiguous, race-free fact, independent of any mail that
+ * arrives concurrently while the scan is running. Callers (e.g. a later incremental-scan stage)
+ * can rely on {@link #getEndUidExclusive()} as the exact upper bound actually covered by this
+ * iteration, safe to persist as the new resume point.
+ *
+ * <p>This is a single-purpose class for scanning a resume range and is not a general
+ * replacement for {@link RecentMessageIterable}: it always iterates oldest-first/ascending and
+ * does not support a {@code newestFirst} option.
+ *
+ * <p>Unlike {@link RecentMessageIterable}, this class does not chunk its fetch: the whole range
+ * is retrieved with a single {@link UIDFolder#getMessagesByUID(long, long)} call. This is an
+ * intentional v1 design decision, not an oversight — the entire point of the scan cache is that
+ * this range is normally small (just the mail that arrived since the last scan), so a single
+ * fetch is the common case. If the range is ever large (e.g. the cache was stale for a long
+ * time), a single large fetch is an acceptable one-time cost.
+ */
+public class UidRangeMessageIterable implements Iterable<Message>
+{
+    private final Folder folder;
+    private final long startUid;
+    private final long endUidExclusive;
+
+    /**
+     * @param folder   a folder that MUST implement {@link UIDFolder}; the caller is expected to
+     *                 have already confirmed this (e.g. via a resume-uid lookup's contract)
+     *                 before constructing this class
+     * @param startUid the inclusive lower bound of the UID range to iterate
+     * @throws IllegalArgumentException if {@code folder} does not implement {@link UIDFolder}
+     * @throws RuntimeException         wrapping any {@link MessagingException} thrown while
+     *                                  snapshotting {@code UIDFolder.getUIDNext()}
+     */
+    public UidRangeMessageIterable(Folder folder, long startUid)
+    {
+        if (!(folder instanceof UIDFolder))
+        {
+            throw new IllegalArgumentException("Folder must implement UIDFolder: " + folder);
+        }
+        this.folder = folder;
+        this.startUid = startUid;
+        try
+        {
+            this.endUidExclusive = ((UIDFolder) folder).getUIDNext();
+        }
+        catch (MessagingException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @return the snapshot of {@code UIDFolder.getUIDNext()} taken in the constructor; this value
+     *         never changes, regardless of subsequent folder mutations or calls to
+     *         {@link #iterator()}
+     */
+    public long getEndUidExclusive()
+    {
+        return endUidExclusive;
+    }
+
+    @Override
+    public Iterator<Message> iterator()
+    {
+        if (startUid >= endUidExclusive)
+        {
+            return Collections.emptyIterator();
+        }
+        try
+        {
+            return new UidRangeMessageIterator(folder, startUid, endUidExclusive);
+        }
+        catch (MessagingException e)
+        {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static class UidRangeMessageIterator implements Iterator<Message>
+    {
+        private final Message[] messages;
+        private int arrayIndex;
+
+        UidRangeMessageIterator(Folder folder, long startUid, long endUidExclusive) throws MessagingException
+        {
+            UIDFolder uidFolder = (UIDFolder) folder;
+            Message[] fetched = uidFolder.getMessagesByUID(startUid, UIDFolder.LASTUID);
+
+            // Race guard: a message may have arrived between the constructor's snapshot of
+            // endUidExclusive and this fetch call. Filter out anything at or beyond the snapshot
+            // so this iteration covers exactly [startUid, endUidExclusive).
+            Message[] inRange = new Message[fetched.length];
+            int count = 0;
+            for (Message m : fetched)
+            {
+                if (uidFolder.getUID(m) < endUidExclusive)
+                {
+                    inRange[count++] = m;
+                }
+            }
+            messages = Arrays.copyOf(inRange, count);
+
+            // Should already be ascending per JavaMail contract, but don't rely on it.
+            Arrays.sort(messages, Comparator.comparingLong(m -> {
+                try
+                {
+                    return uidFolder.getUID(m);
+                }
+                catch (MessagingException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }));
+
+            FetchProfile fp = new FetchProfile();
+            fp.add(FetchProfile.Item.ENVELOPE);
+            folder.fetch(messages, fp);
+
+            arrayIndex = 0;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return arrayIndex < messages.length;
+        }
+
+        @Override
+        public Message next()
+        {
+            return messages[arrayIndex++];
+        }
+
+        @Override
+        public void remove()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/main/java/org/ethelred/mymailtool2/javascript/JavascriptFileConfiguration.java
+++ b/src/main/java/org/ethelred/mymailtool2/javascript/JavascriptFileConfiguration.java
@@ -307,6 +307,18 @@ class JavascriptFileConfiguration extends BaseFileConfiguration
         return false;
     }
 
+    @Override
+    public String getScanStateFile()
+    {
+        return config.getString("scanStateFile");
+    }
+
+    @Override
+    public boolean disableScanCache()
+    {
+        return Boolean.parseBoolean(config.getString("disableScanCache"));
+    }
+
     private abstract class OperationBuilder
     {
         protected Predicate<Message> delegate;

--- a/src/main/java/org/ethelred/mymailtool2/propertiesfile/PropertiesFileConfiguration.java
+++ b/src/main/java/org/ethelred/mymailtool2/propertiesfile/PropertiesFileConfiguration.java
@@ -282,6 +282,18 @@ class PropertiesFileConfiguration extends BaseFileConfiguration
         return false;
     }
 
+    @Override
+    public String getScanStateFile()
+    {
+        return delegate.getProperty("mymailtool.scanstatefile");
+    }
+
+    @Override
+    public boolean disableScanCache()
+    {
+        return Boolean.parseBoolean(delegate.getProperty("mymailtool.noscancache"));
+    }
+
     private void addFileLocations(String filenames)
     {
         for (String fn : filenames.split(","))

--- a/src/test/java/org/ethelred/mymailtool2/ApplyMatchOperationsTaskTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/ApplyMatchOperationsTaskTest.java
@@ -356,6 +356,54 @@ public class ApplyMatchOperationsTaskTest
     }
 
     @Test
+    public void testTransientUidNextFailureDuringResumeFallsBackToFullScanForThatFolder(@TempDir File tempDir)
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable("F1", true);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar c = Calendar.getInstance();
+        c.set(2013, Calendar.JANUARY, 1);
+        for (int i = 1; i <= 5; i++)
+        {
+            c.add(Calendar.DATE, 1);
+            data.addMessage("F1", MockMessage.create(dateFormat.format(c.getTime()), "foo@example.com", String.valueOf(i)));
+        }
+        ClockFactory.setClock(c.getTimeInMillis());
+
+        File stateFile = new File(tempDir, "scan-state.properties");
+        MockDefaultConfiguration config = configWithStateFile(stateFile);
+
+        // Run 1: establishes a valid resume point (nextUid = 6) without moving messages, so F1
+        // still has all 5 messages to prove a "fallback to full scan" against.
+        ApplyMatchOperationsTask task1 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll1 = new AgeMatcher("0 days", true, task1);
+        task1.addRule("F1", matchAll1, List.of(matchAll1), new TrackMatchMessageOperation(), false);
+        MailToolContext context1 = new DefaultContext(config, FP1);
+        runTask(task1, context1);
+        assertThat(((DefaultContext) context1).messageCheckedCount).isEqualTo(5);
+        assertThat(data.folderSize("F1")).isEqualTo(5);
+
+        // Simulate a transient IMAP failure at exactly the getUIDNext() snapshot call made
+        // inside UidRangeMessageIterable's constructor, on the resume path.
+        data.setUidNextFailure("F1", true);
+
+        // Run 2: a valid resume UID exists (from run 1), so readMessages() takes the resume
+        // path and constructs a UidRangeMessageIterable, whose constructor's getUIDNext() call
+        // fails. This must degrade gracefully to a full scan of this one folder, NOT propagate
+        // out of run() and abort the whole task.
+        ApplyMatchOperationsTask task2 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll2 = new AgeMatcher("0 days", true, task2);
+        task2.addRule("F1", matchAll2, List.of(matchAll2), new TrackMatchMessageOperation(), false);
+        MailToolContext context2 = new DefaultContext(config, FP1);
+        runTask(task2, context2);
+
+        // All 5 messages were checked via the full-scan fallback -- proving the failure was
+        // contained to this folder's resume-path lookup rather than aborting the whole run
+        // (which would have left messageCheckedCount at 0 for every remaining folder).
+        assertThat(((DefaultContext) context2).messageCheckedCount).isEqualTo(5);
+    }
+
+    @Test
     public void testDisableScanCacheAlwaysFullRescan(@TempDir File tempDir)
     {
         MockData data = MockData.getInstance();

--- a/src/test/java/org/ethelred/mymailtool2/ApplyMatchOperationsTaskTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/ApplyMatchOperationsTaskTest.java
@@ -10,12 +10,15 @@ import org.ethelred.mymailtool2.mock.MockMessage;
 import org.ethelred.util.ClockFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import javax.annotation.Nullable;
 import jakarta.mail.Message;
+import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.List;
+import java.util.Optional;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -145,6 +148,319 @@ public class ApplyMatchOperationsTaskTest
         assertThat(data.folderSize("F2")).isEqualTo(1);
         assertThat(data.folderSize("F3")).isEqualTo(2);
         assertThat(((DefaultContext) context).messageCheckedCount).isEqualTo(4);
+    }
+
+    // --- Stage 8: scan cache wiring ---------------------------------------------------------
+
+    private static final String FP1 = "fp-1";
+    private static final String FP2 = "fp-2";
+    private static final String ACCOUNT_KEY = "unknown@";
+
+    private MockDefaultConfiguration configWithStateFile(File stateFile)
+    {
+        return new MockDefaultConfiguration()
+        {
+            @Override
+            public String getScanStateFile()
+            {
+                return stateFile.getAbsolutePath();
+            }
+        };
+    }
+
+    private MockDefaultConfiguration configWithScanCacheDisabled(File stateFile)
+    {
+        return new MockDefaultConfiguration()
+        {
+            @Override
+            public String getScanStateFile()
+            {
+                return stateFile.getAbsolutePath();
+            }
+
+            @Override
+            public boolean disableScanCache()
+            {
+                return true;
+            }
+        };
+    }
+
+    private void runTask(ApplyMatchOperationsTask task, MailToolContext context)
+    {
+        try
+        {
+            context.connect();
+            task.init(context);
+            task.run();
+        }
+        finally
+        {
+            context.disconnect();
+        }
+    }
+
+    @Test
+    public void testFirstRunPopulatesScanState(@TempDir File tempDir)
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable("F1", true);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar c = Calendar.getInstance();
+        c.set(2013, Calendar.JANUARY, 1);
+        for (int i = 1; i <= 5; i++)
+        {
+            c.add(Calendar.DATE, 1);
+            data.addMessage("F1", MockMessage.create(dateFormat.format(c.getTime()), "foo@example.com", String.valueOf(i)));
+        }
+        ClockFactory.setClock(c.getTimeInMillis());
+
+        File stateFile = new File(tempDir, "scan-state.properties");
+        MockDefaultConfiguration config = configWithStateFile(stateFile);
+
+        ApplyMatchOperationsTask task = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll = new AgeMatcher("0 days", true, task);
+        task.addRule("F1", matchAll, List.of(matchAll), new MoveOperation("F2"), false);
+
+        MailToolContext context = new DefaultContext(config, FP1);
+        runTask(task, context);
+
+        assertThat(data.folderSize("F1")).isEqualTo(0);
+        assertThat(data.folderSize("F2")).isEqualTo(5);
+        assertThat(((DefaultContext) context).messageCheckedCount).isEqualTo(5);
+
+        ScanState state = ScanState.loadOrEmpty(stateFile);
+        Optional<ScanState.FolderScanState> stored = state.get(ACCOUNT_KEY, "f1");
+        assertThat(stored.isPresent()).isTrue();
+        assertThat(stored.get().nextUid()).isEqualTo(6L);
+    }
+
+    @Test
+    public void testSecondRunNoNewMailChecksZero(@TempDir File tempDir)
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable("F1", true);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar c = Calendar.getInstance();
+        c.set(2013, Calendar.JANUARY, 1);
+        for (int i = 1; i <= 5; i++)
+        {
+            c.add(Calendar.DATE, 1);
+            data.addMessage("F1", MockMessage.create(dateFormat.format(c.getTime()), "foo@example.com", String.valueOf(i)));
+        }
+        ClockFactory.setClock(c.getTimeInMillis());
+
+        File stateFile = new File(tempDir, "scan-state.properties");
+        MockDefaultConfiguration config = configWithStateFile(stateFile);
+
+        ApplyMatchOperationsTask task1 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll1 = new AgeMatcher("0 days", true, task1);
+        task1.addRule("F1", matchAll1, List.of(matchAll1), new MoveOperation("F2"), false);
+        MailToolContext context1 = new DefaultContext(config, FP1);
+        runTask(task1, context1);
+        assertThat(((DefaultContext) context1).messageCheckedCount).isEqualTo(5);
+
+        // second run, same folder + state file + fingerprint, no new mail in between
+        ApplyMatchOperationsTask task2 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll2 = new AgeMatcher("0 days", true, task2);
+        task2.addRule("F1", matchAll2, List.of(matchAll2), new MoveOperation("F2"), false);
+        MailToolContext context2 = new DefaultContext(config, FP1);
+        runTask(task2, context2);
+
+        assertThat(((DefaultContext) context2).messageCheckedCount).isEqualTo(0);
+    }
+
+    @Test
+    public void testSecondRunWithNewMailChecksOnlyNewMessages(@TempDir File tempDir)
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable("F1", true);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar c = Calendar.getInstance();
+        c.set(2013, Calendar.JANUARY, 1);
+        for (int i = 1; i <= 5; i++)
+        {
+            c.add(Calendar.DATE, 1);
+            data.addMessage("F1", MockMessage.create(dateFormat.format(c.getTime()), "foo@example.com", String.valueOf(i)));
+        }
+        ClockFactory.setClock(c.getTimeInMillis());
+
+        File stateFile = new File(tempDir, "scan-state.properties");
+        MockDefaultConfiguration config = configWithStateFile(stateFile);
+
+        ApplyMatchOperationsTask task1 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll1 = new AgeMatcher("0 days", true, task1);
+        task1.addRule("F1", matchAll1, List.of(matchAll1), new MoveOperation("F2"), false);
+        MailToolContext context1 = new DefaultContext(config, FP1);
+        runTask(task1, context1);
+        assertThat(((DefaultContext) context1).messageCheckedCount).isEqualTo(5);
+        assertThat(data.folderSize("F2")).isEqualTo(5);
+
+        // add 2 new messages after the first run, then advance the clock so they're not "too new"
+        int newMessageCount = 2;
+        for (int i = 0; i < newMessageCount; i++)
+        {
+            c.add(Calendar.DATE, 1);
+            data.addMessage("F1", MockMessage.create(dateFormat.format(c.getTime()), "foo@example.com", "new" + i));
+        }
+        ClockFactory.setClock(c.getTimeInMillis());
+
+        ApplyMatchOperationsTask task2 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll2 = new AgeMatcher("0 days", true, task2);
+        task2.addRule("F1", matchAll2, List.of(matchAll2), new MoveOperation("F2"), false);
+        MailToolContext context2 = new DefaultContext(config, FP1);
+        runTask(task2, context2);
+
+        assertThat(((DefaultContext) context2).messageCheckedCount).isEqualTo(newMessageCount);
+        assertThat(data.folderSize("F2")).isEqualTo(5 + newMessageCount);
+    }
+
+    @Test
+    public void testFingerprintChangeForcesFullRescan(@TempDir File tempDir)
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable("F1", true);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar c = Calendar.getInstance();
+        c.set(2013, Calendar.JANUARY, 1);
+        for (int i = 1; i <= 5; i++)
+        {
+            c.add(Calendar.DATE, 1);
+            data.addMessage("F1", MockMessage.create(dateFormat.format(c.getTime()), "foo@example.com", String.valueOf(i)));
+        }
+        ClockFactory.setClock(c.getTimeInMillis());
+
+        File stateFile = new File(tempDir, "scan-state.properties");
+        MockDefaultConfiguration config = configWithStateFile(stateFile);
+
+        // Rule matches everything but does not move the messages, so a leftover, unmoved
+        // population remains in F1 after run 1: this is what lets us tell "resumed, 0 checked"
+        // apart from "rescanned in full" in run 2.
+        ApplyMatchOperationsTask task1 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll1 = new AgeMatcher("0 days", true, task1);
+        task1.addRule("F1", matchAll1, List.of(matchAll1), new TrackMatchMessageOperation(), false);
+        MailToolContext context1 = new DefaultContext(config, FP1);
+        runTask(task1, context1);
+        assertThat(((DefaultContext) context1).messageCheckedCount).isEqualTo(5);
+        assertThat(data.folderSize("F1")).isEqualTo(5);
+
+        // second run, same folder + state file, but a different fingerprint: cache must be
+        // treated as invalid, forcing a full rescan of the still-present 5 messages
+        ApplyMatchOperationsTask task2 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll2 = new AgeMatcher("0 days", true, task2);
+        task2.addRule("F1", matchAll2, List.of(matchAll2), new TrackMatchMessageOperation(), false);
+        MailToolContext context2 = new DefaultContext(config, FP2);
+        runTask(task2, context2);
+
+        assertThat(((DefaultContext) context2).messageCheckedCount).isEqualTo(5);
+    }
+
+    @Test
+    public void testDisableScanCacheAlwaysFullRescan(@TempDir File tempDir)
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable("F1", true);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar c = Calendar.getInstance();
+        c.set(2013, Calendar.JANUARY, 1);
+        for (int i = 1; i <= 5; i++)
+        {
+            c.add(Calendar.DATE, 1);
+            data.addMessage("F1", MockMessage.create(dateFormat.format(c.getTime()), "foo@example.com", String.valueOf(i)));
+        }
+        ClockFactory.setClock(c.getTimeInMillis());
+
+        File stateFile = new File(tempDir, "scan-state.properties");
+        MockDefaultConfiguration cacheEnabledConfig = configWithStateFile(stateFile);
+
+        // First run: normal cache-enabled context, establishes a valid resume point.
+        ApplyMatchOperationsTask task1 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll1 = new AgeMatcher("0 days", true, task1);
+        task1.addRule("F1", matchAll1, List.of(matchAll1), new TrackMatchMessageOperation(), false);
+        MailToolContext context1 = new DefaultContext(cacheEnabledConfig, FP1);
+        runTask(task1, context1);
+        assertThat(((DefaultContext) context1).messageCheckedCount).isEqualTo(5);
+        assertThat(data.folderSize("F1")).isEqualTo(5);
+
+        // Second run: same state file, same fingerprint, but scan cache disabled -- must still
+        // check every message despite a valid, matching cache entry existing on disk.
+        MockDefaultConfiguration cacheDisabledConfig = configWithScanCacheDisabled(stateFile);
+        ApplyMatchOperationsTask task2 = ApplyMatchOperationsTask.create();
+        Predicate<Message> matchAll2 = new AgeMatcher("0 days", true, task2);
+        task2.addRule("F1", matchAll2, List.of(matchAll2), new TrackMatchMessageOperation(), false);
+        MailToolContext context2 = new DefaultContext(cacheDisabledConfig, FP1);
+        runTask(task2, context2);
+
+        assertThat(((DefaultContext) context2).messageCheckedCount).isEqualTo(5);
+    }
+
+    @Test
+    public void testAgeMatcherShortcutMessageIsReExaminedOnceOldEnough(@TempDir File tempDir)
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable("F1", true);
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+        Calendar c = Calendar.getInstance();
+        c.set(2013, Calendar.JANUARY, 1);
+        // messages dated 2013-01-02 .. 2013-01-06, UIDs 1..5 in that same order
+        for (int i = 1; i <= 5; i++)
+        {
+            c.add(Calendar.DATE, 1);
+            data.addMessage("F1", MockMessage.create(dateFormat.format(c.getTime()), "foo@example.com", String.valueOf(i)));
+        }
+        ClockFactory.setClock(c.getTimeInMillis()); // clock = 2013-01-06
+
+        File stateFile = new File(tempDir, "scan-state.properties");
+        MockDefaultConfiguration config = configWithStateFile(stateFile);
+
+        // Run 1: age >= 3 days matches (moves to F2). Oldest-first traversal:
+        //   msg1 (01-02, age 4d) matches -> moved
+        //   msg2 (01-03, age 3d) matches -> moved
+        //   msg3 (01-04, age 2d) too new -> ShortcutFolderScanException, scan stops here
+        // msg3 is therefore "considered but not resolved": it must remain available for a
+        // future run once it becomes old enough, per the plan's central correctness claim.
+        ApplyMatchOperationsTask task1 = ApplyMatchOperationsTask.create();
+        Predicate<Message> age1 = new AgeMatcher("3 days", true, task1);
+        task1.addRule("F1", Predicates.and(Predicates.alwaysTrue(), age1), List.of(age1), new MoveOperation("F2"), false);
+        MailToolContext context1 = new DefaultContext(config, FP1);
+        runTask(task1, context1);
+
+        assertThat(data.folderSize("F1")).isEqualTo(3); // msg3, msg4, msg5 remain
+        assertThat(data.folderSize("F2")).isEqualTo(2); // msg1, msg2 moved
+        assertThat(((DefaultContext) context1).messageCheckedCount).isEqualTo(3);
+
+        // The persisted resume point must be AT msg3 (UID 3, the unresolved shortcut message),
+        // not past it and not the folder's full UIDNEXT (6).
+        ScanState stateAfterRun1 = ScanState.loadOrEmpty(stateFile);
+        Optional<ScanState.FolderScanState> storedAfterRun1 = stateAfterRun1.get(ACCOUNT_KEY, "f1");
+        assertThat(storedAfterRun1.isPresent()).isTrue();
+        assertThat(storedAfterRun1.get().nextUid()).isEqualTo(3L);
+
+        // Advance the clock by 2 days (to 2013-01-08) so msg3 and msg4 are now old enough
+        // (age 4d and 3d respectively); msg5 (age 2d) is still too new and will shortcut again.
+        c.add(Calendar.DATE, 2);
+        ClockFactory.setClock(c.getTimeInMillis());
+
+        ApplyMatchOperationsTask task2 = ApplyMatchOperationsTask.create();
+        Predicate<Message> age2 = new AgeMatcher("3 days", true, task2);
+        task2.addRule("F1", Predicates.and(Predicates.alwaysTrue(), age2), List.of(age2), new MoveOperation("F2"), false);
+        MailToolContext context2 = new DefaultContext(config, FP1);
+        runTask(task2, context2);
+
+        // (a) msg3 and msg4, previously blocked by the shortcut, are now correctly re-examined
+        // and matched/moved -- proving the cache did not skip them.
+        assertThat(data.folderSize("F1")).isEqualTo(1); // only msg5 remains
+        assertThat(data.folderSize("F2")).isEqualTo(4); // msg1, msg2 (run 1) + msg3, msg4 (run 2)
+
+        // (b) only the previously-unresolved tail (msg3, msg4, msg5) is re-checked in run 2;
+        // msg1 and msg2, already fully resolved and moved in run 1, are correctly NOT re-checked.
+        assertThat(((DefaultContext) context2).messageCheckedCount).isEqualTo(3);
+
+        // The resume point now moves to msg5 (UID 5), the new unresolved shortcut message.
+        ScanState stateAfterRun2 = ScanState.loadOrEmpty(stateFile);
+        Optional<ScanState.FolderScanState> storedAfterRun2 = stateAfterRun2.get(ACCOUNT_KEY, "f1");
+        assertThat(storedAfterRun2.isPresent()).isTrue();
+        assertThat(storedAfterRun2.get().nextUid()).isEqualTo(5L);
     }
 
 }

--- a/src/test/java/org/ethelred/mymailtool2/CommandLineConfigurationTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/CommandLineConfigurationTest.java
@@ -1,0 +1,36 @@
+package org.ethelred.mymailtool2;
+
+import org.junit.jupiter.api.Test;
+import org.kohsuke.args4j.CmdLineParser;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class CommandLineConfigurationTest
+{
+    @Test
+    public void testNoScanCacheFlagSetsDisableScanCache() throws Exception
+    {
+        CommandLineConfiguration clc = new CommandLineConfiguration();
+        CmdLineParser parser = new CmdLineParser(clc);
+        parser.parseArgument("--no-scan-cache");
+
+        assertThat(clc.disableScanCache()).isTrue();
+    }
+
+    @Test
+    public void testDisableScanCacheDefaultsToFalse() throws Exception
+    {
+        CommandLineConfiguration clc = new CommandLineConfiguration();
+        CmdLineParser parser = new CmdLineParser(clc);
+        parser.parseArgument();
+
+        assertThat(clc.disableScanCache()).isFalse();
+    }
+
+    @Test
+    public void testGetScanStateFileIsNull()
+    {
+        CommandLineConfiguration clc = new CommandLineConfiguration();
+        assertThat(clc.getScanStateFile()).isNull();
+    }
+}

--- a/src/test/java/org/ethelred/mymailtool2/CompositeConfigurationTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/CompositeConfigurationTest.java
@@ -108,6 +108,18 @@ public class CompositeConfigurationTest
             public boolean randomTraversal() {
                 return false;
             }
+
+            @Override
+            public String getScanStateFile()
+            {
+                return null;
+            }
+
+            @Override
+            public boolean disableScanCache()
+            {
+                return false;
+            }
         };
 
         MailToolConfiguration comp = new CompositeConfiguration(mock);
@@ -152,5 +164,31 @@ public class CompositeConfigurationTest
         verify(mockDefault).getFileLocations();
         verify(mockFile1).getFileLocations();
         verify(mockFile2).getFileLocations();
+    }
+
+    @Test
+    public void testGetScanStateFilePicksFirstNonNull()
+    {
+        final MailToolConfiguration mockFirst = mock(MailToolConfiguration.class);
+        final MailToolConfiguration mockSecond = mock(MailToolConfiguration.class);
+        when(mockFirst.getScanStateFile()).thenReturn(null);
+        when(mockSecond.getScanStateFile()).thenReturn("/path/to/scan-state.properties");
+
+        CompositeConfiguration cmp = new CompositeConfiguration(mockFirst, mockSecond);
+
+        assertThat(cmp.getScanStateFile()).isEqualTo("/path/to/scan-state.properties");
+    }
+
+    @Test
+    public void testDisableScanCacheTrueIfAnySubConfigTrue()
+    {
+        final MailToolConfiguration mockFirst = mock(MailToolConfiguration.class);
+        final MailToolConfiguration mockSecond = mock(MailToolConfiguration.class);
+        when(mockFirst.disableScanCache()).thenReturn(false);
+        when(mockSecond.disableScanCache()).thenReturn(true);
+
+        CompositeConfiguration cmp = new CompositeConfiguration(mockFirst, mockSecond);
+
+        assertThat(cmp.disableScanCache()).isTrue();
     }
 }

--- a/src/test/java/org/ethelred/mymailtool2/ConfigFingerprintTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/ConfigFingerprintTest.java
@@ -1,0 +1,131 @@
+package org.ethelred.mymailtool2;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * tests for ConfigFingerprint
+ */
+public class ConfigFingerprintTest
+{
+    @Test
+    public void sameFileSameContentHashedTwiceIsIdentical(@TempDir File dir) throws IOException
+    {
+        File f = new File(dir, "a.conf");
+        Files.writeString(f.toPath(), "content");
+
+        String fp1 = ConfigFingerprint.compute(List.of(f));
+        String fp2 = ConfigFingerprint.compute(List.of(f));
+
+        assertThat(fp1).isEqualTo(fp2);
+    }
+
+    @Test
+    public void sameContentDifferentPathsProducesDifferentFingerprint(@TempDir File dir) throws IOException
+    {
+        File a = new File(dir, "a.conf");
+        File b = new File(dir, "b.conf");
+        Files.writeString(a.toPath(), "content");
+        Files.writeString(b.toPath(), "content");
+
+        String fpA = ConfigFingerprint.compute(List.of(a));
+        String fpB = ConfigFingerprint.compute(List.of(b));
+
+        assertThat(fpA).isNotEqualTo(fpB);
+    }
+
+    @Test
+    public void contentChangeProducesDifferentFingerprint(@TempDir File dir) throws IOException
+    {
+        File f = new File(dir, "a.conf");
+        Files.writeString(f.toPath(), "content");
+        String fp1 = ConfigFingerprint.compute(List.of(f));
+
+        Files.writeString(f.toPath(), "different content");
+        String fp2 = ConfigFingerprint.compute(List.of(f));
+
+        assertThat(fp1).isNotEqualTo(fp2);
+    }
+
+    @Test
+    public void addingFileToListChangesFingerprint(@TempDir File dir) throws IOException
+    {
+        File a = new File(dir, "a.conf");
+        File b = new File(dir, "b.conf");
+        Files.writeString(a.toPath(), "content-a");
+        Files.writeString(b.toPath(), "content-b");
+
+        String fpBefore = ConfigFingerprint.compute(List.of(a));
+        String fpAfter = ConfigFingerprint.compute(List.of(a, b));
+
+        assertThat(fpBefore).isNotEqualTo(fpAfter);
+    }
+
+    @Test
+    public void removingFileFromListChangesFingerprint(@TempDir File dir) throws IOException
+    {
+        File a = new File(dir, "a.conf");
+        File b = new File(dir, "b.conf");
+        Files.writeString(a.toPath(), "content-a");
+        Files.writeString(b.toPath(), "content-b");
+
+        String fpBefore = ConfigFingerprint.compute(List.of(a, b));
+        String fpAfter = ConfigFingerprint.compute(List.of(a));
+
+        assertThat(fpBefore).isNotEqualTo(fpAfter);
+    }
+
+    @Test
+    public void missingFileDoesNotThrowAndProducesFingerprint(@TempDir File dir) throws IOException
+    {
+        File missing = new File(dir, "does-not-exist.conf");
+
+        String fingerprint = ConfigFingerprint.compute(List.of(missing));
+
+        assertThat(fingerprint).isNotNull();
+    }
+
+    @Test
+    public void missingFileFingerprintDiffersFromExistingFileWithContent(@TempDir File dir) throws IOException
+    {
+        File f = new File(dir, "maybe.conf");
+
+        String fpMissing = ConfigFingerprint.compute(List.of(f));
+
+        Files.writeString(f.toPath(), "some content");
+        String fpExisting = ConfigFingerprint.compute(List.of(f));
+
+        assertThat(fpMissing).isNotEqualTo(fpExisting);
+    }
+
+    @Test
+    public void emptyFileListProducesValidDeterministicFingerprint() throws IOException
+    {
+        String fp1 = ConfigFingerprint.compute(List.of());
+        String fp2 = ConfigFingerprint.compute(List.of());
+
+        assertThat(fp1).isNotNull();
+        assertThat(fp1).isEqualTo(fp2);
+    }
+
+    @Test
+    public void orderOfFilesAffectsFingerprint(@TempDir File dir) throws IOException
+    {
+        File a = new File(dir, "a.conf");
+        File b = new File(dir, "b.conf");
+        Files.writeString(a.toPath(), "content-a");
+        Files.writeString(b.toPath(), "content-b");
+
+        String fpAB = ConfigFingerprint.compute(List.of(a, b));
+        String fpBA = ConfigFingerprint.compute(List.of(b, a));
+
+        assertThat(fpAB).isNotEqualTo(fpBA);
+    }
+}

--- a/src/test/java/org/ethelred/mymailtool2/ConfigFingerprintTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/ConfigFingerprintTest.java
@@ -93,13 +93,17 @@ public class ConfigFingerprintTest
     }
 
     @Test
-    public void missingFileFingerprintDiffersFromExistingFileWithContent(@TempDir File dir) throws IOException
+    public void missingFileFingerprintDiffersFromExistingEmptyFile(@TempDir File dir) throws IOException
     {
         File f = new File(dir, "maybe.conf");
 
         String fpMissing = ConfigFingerprint.compute(List.of(f));
 
-        Files.writeString(f.toPath(), "some content");
+        // Create the file but leave it empty: content contributes zero bytes
+        // either way, so the only difference in the hashed byte stream is the
+        // exists flag (0 vs 1). This isolates the exists-flag as load-bearing,
+        // rather than conflating it with a content difference.
+        Files.writeString(f.toPath(), "");
         String fpExisting = ConfigFingerprint.compute(List.of(f));
 
         assertThat(fpMissing).isNotEqualTo(fpExisting);

--- a/src/test/java/org/ethelred/mymailtool2/DefaultConfigurationTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/DefaultConfigurationTest.java
@@ -36,4 +36,22 @@ public class DefaultConfigurationTest
         assertThat(config.getFileHandlers().iterator().next())
                 .isInstanceOf(PropertiesFileConfigurationHandler.class);
     }
+
+    @Test
+    public void testGetScanStateFileReturnsPathEndingInScanStateProperties()
+    {
+        DefaultConfiguration config = new DefaultConfiguration();
+        String scanStateFile = config.getScanStateFile();
+
+        assertThat(scanStateFile).isNotNull();
+        assertThat(scanStateFile).endsWith("scan-state.properties");
+        assertThat(scanStateFile).contains("mymailtool");
+    }
+
+    @Test
+    public void testDisableScanCacheDefaultsToFalse()
+    {
+        DefaultConfiguration config = new DefaultConfiguration();
+        assertThat(config.disableScanCache()).isFalse();
+    }
 }

--- a/src/test/java/org/ethelred/mymailtool2/DefaultConfigurationTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/DefaultConfigurationTest.java
@@ -54,4 +54,15 @@ public class DefaultConfigurationTest
         DefaultConfiguration config = new DefaultConfiguration();
         assertThat(config.disableScanCache()).isFalse();
     }
+
+    @Test
+    public void testGetScanStateFileNeverThrows()
+    {
+        // getScanStateFile() wraps ProjectDirectories.from(...) in a try/catch so that,
+        // as the always-safe fallback layer, it returns null instead of propagating an
+        // exception (e.g. on an unsupported OS) - hard to trigger for real in a unit test,
+        // but this at least pins down that calling it under normal conditions never throws.
+        DefaultConfiguration config = new DefaultConfiguration();
+        assertThat(config.getScanStateFile()).isNotNull();
+    }
 }

--- a/src/test/java/org/ethelred/mymailtool2/DefaultContextTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/DefaultContextTest.java
@@ -95,4 +95,47 @@ public class DefaultContextTest
             context2.disconnect();
         }
     }
+
+    @Test
+    public void nullUser_doesNotBlowUpAndProducesStableKey() throws MessagingException
+    {
+        // MockDefaultConfiguration.getUser() returns null, exercising the "no user configured"
+        // guard in the account-key computation: it should fall back to a stable placeholder
+        // rather than embedding the literal string "null", and still work correctly end to end.
+        File stateFile = new File(tempDir, "scan-state.json");
+        MockDefaultConfiguration config = new MockDefaultConfiguration()
+        {
+            @Override
+            public String getScanStateFile()
+            {
+                return stateFile.getAbsolutePath();
+            }
+        };
+        assertThat(config.getUser()).isNull();
+
+        DefaultContext context1 = new DefaultContext(config, "fingerprint-1");
+        context1.connect();
+        try
+        {
+            Folder folder = context1.getFolder("Folder");
+            assertThat(context1.getFolderScanCache().getResumeUid(folder)).isEqualTo(OptionalLong.empty());
+            context1.getFolderScanCache().recordScanCompletion(folder, 7L, null, true);
+        }
+        finally
+        {
+            context1.disconnect();
+        }
+
+        DefaultContext context2 = new DefaultContext(config, "fingerprint-1");
+        context2.connect();
+        try
+        {
+            Folder folder = context2.getFolder("Folder");
+            assertThat(context2.getFolderScanCache().getResumeUid(folder)).isEqualTo(OptionalLong.of(7L));
+        }
+        finally
+        {
+            context2.disconnect();
+        }
+    }
 }

--- a/src/test/java/org/ethelred/mymailtool2/DefaultContextTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/DefaultContextTest.java
@@ -1,0 +1,98 @@
+package org.ethelred.mymailtool2;
+
+import java.io.File;
+import java.util.OptionalLong;
+
+import org.ethelred.mymailtool2.mock.MockData;
+import org.ethelred.mymailtool2.mock.MockDefaultConfiguration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import jakarta.mail.Folder;
+import jakarta.mail.MessagingException;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Tests for {@link DefaultContext}'s {@link FolderScanCache} wiring.
+ */
+public class DefaultContextTest
+{
+    @TempDir
+    File tempDir;
+
+    @BeforeEach
+    public void setup()
+    {
+        MockData data = MockData.getInstance();
+        data.addFolder("Folder");
+        data.setUidCapable("Folder", true);
+    }
+
+    @AfterEach
+    public void cleanup()
+    {
+        MockData.clear();
+    }
+
+    @Test
+    public void oneArgConstructor_folderScanCacheAlwaysEmpty() throws MessagingException
+    {
+        DefaultContext context = new DefaultContext(new MockDefaultConfiguration());
+        context.connect();
+        try
+        {
+            Folder folder = context.getFolder("Folder");
+            assertThat(context.getFolderScanCache().getResumeUid(folder)).isEqualTo(OptionalLong.empty());
+        }
+        finally
+        {
+            context.disconnect();
+        }
+    }
+
+    @Test
+    public void twoArgConstructor_wiresWorkingFolderScanCache() throws MessagingException
+    {
+        File stateFile = new File(tempDir, "scan-state.json");
+        MockDefaultConfiguration config = new MockDefaultConfiguration()
+        {
+            @Override
+            public String getScanStateFile()
+            {
+                return stateFile.getAbsolutePath();
+            }
+        };
+
+        DefaultContext context1 = new DefaultContext(config, "fingerprint-1");
+        context1.connect();
+        try
+        {
+            assertThat(context1.getFolderScanCache()).isNotNull();
+            Folder folder = context1.getFolder("Folder");
+            assertThat(context1.getFolderScanCache().getResumeUid(folder)).isEqualTo(OptionalLong.empty());
+            context1.getFolderScanCache().recordScanCompletion(folder, 42L, null, true);
+        }
+        finally
+        {
+            context1.disconnect();
+        }
+
+        // A second context, constructed with the same config + fingerprint, should see the
+        // recorded resume point, proving the account key / state file / fingerprint used by
+        // the first context's cache are the ones actually wired through.
+        DefaultContext context2 = new DefaultContext(config, "fingerprint-1");
+        context2.connect();
+        try
+        {
+            Folder folder = context2.getFolder("Folder");
+            assertThat(context2.getFolderScanCache().getResumeUid(folder)).isEqualTo(OptionalLong.of(42L));
+        }
+        finally
+        {
+            context2.disconnect();
+        }
+    }
+}

--- a/src/test/java/org/ethelred/mymailtool2/DefaultFolderScanCacheTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/DefaultFolderScanCacheTest.java
@@ -255,6 +255,25 @@ public class DefaultFolderScanCacheTest
     }
 
     @Test
+    public void nullFingerprintRecordScanCompletionIsNoOpAndDoesNotOverwritePriorState(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint(FINGERPRINT);
+        seed.put(ACCOUNT, FOLDER_NAME, new ScanState.FolderScanState(1L, 42L));
+        seed.save(stateFile);
+
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, null, false);
+        cache.recordScanCompletion(folder, 999L, null, true);
+
+        ScanState reloaded = ScanState.loadOrEmpty(stateFile);
+        assertThat(reloaded.getConfigFingerprint()).isEqualTo(FINGERPRINT);
+        assertThat(reloaded.get(ACCOUNT, FOLDER_NAME))
+                .hasValue(new ScanState.FolderScanState(1L, 42L));
+    }
+
+    @Test
     public void disabledRecordScanCompletionIsTrueNoOp(@TempDir File dir) throws MessagingException
     {
         File stateFile = new File(dir, "scan-state.properties");
@@ -291,7 +310,11 @@ public class DefaultFolderScanCacheTest
     @Test
     public void ioFailureOnSaveIsSwallowedNotPropagated(@TempDir File dir) throws MessagingException
     {
-        // Use a directory as the "state file" so writing to it fails with IOException.
+        // Use a directory as the "state file". ScanState.save() writes its content to a sibling
+        // ".tmp" file first (which succeeds, since that path doesn't exist), then fails only at
+        // the final atomic Files.move() step, because it can't move a regular file onto an
+        // existing directory. This reliably reproduces an IOException from the rename, not from
+        // the initial write.
         File stateFileAsDirectory = new File(dir, "state-is-a-directory");
         assertThat(stateFileAsDirectory.mkdirs()).isTrue();
 

--- a/src/test/java/org/ethelred/mymailtool2/DefaultFolderScanCacheTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/DefaultFolderScanCacheTest.java
@@ -1,0 +1,323 @@
+package org.ethelred.mymailtool2;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+
+import org.ethelred.mymailtool2.mock.MockAuthenticator;
+import org.ethelred.mymailtool2.mock.MockData;
+import org.ethelred.mymailtool2.mock.MockMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Tests for {@link DefaultFolderScanCache}.
+ */
+public class DefaultFolderScanCacheTest
+{
+    private static final String ACCOUNT = "jaq@example.com";
+    private static final String FOLDER_NAME = "INBOX";
+    private static final String FINGERPRINT = "fingerprint-1";
+
+    private Store getStore() throws MessagingException
+    {
+        Properties props = new Properties();
+        props.setProperty("mail.store.protocol", "imap");
+        Session ss = Session.getDefaultInstance(props, new MockAuthenticator());
+        return ss.getStore();
+    }
+
+    @BeforeEach
+    public void setUp()
+    {
+        MockData.clear();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        MockData.clear();
+    }
+
+    private Folder uidFolder() throws MessagingException
+    {
+        MockData.getInstance().setUidCapable(FOLDER_NAME, true);
+        return getStore().getFolder(FOLDER_NAME);
+    }
+
+    private Folder plainFolder() throws MessagingException
+    {
+        return getStore().getFolder(FOLDER_NAME);
+    }
+
+    // --- getResumeUid failure-mode table ---
+
+    @Test
+    public void disabledAlwaysEmptyEvenWithMatchingFingerprintAndPriorState(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint(FINGERPRINT);
+        seed.put(ACCOUNT, FOLDER_NAME, new ScanState.FolderScanState(1L, 42L));
+        seed.save(stateFile);
+
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, true);
+
+        assertThat(cache.getResumeUid(folder).isPresent()).isFalse();
+    }
+
+    @Test
+    public void nullStateFileAlwaysEmpty() throws MessagingException
+    {
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, null, FINGERPRINT, false);
+
+        assertThat(cache.getResumeUid(folder).isPresent()).isFalse();
+    }
+
+    @Test
+    public void nullCurrentFingerprintAlwaysEmpty(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint(FINGERPRINT);
+        seed.put(ACCOUNT, FOLDER_NAME, new ScanState.FolderScanState(1L, 42L));
+        seed.save(stateFile);
+
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, null, false);
+
+        assertThat(cache.getResumeUid(folder).isPresent()).isFalse();
+    }
+
+    @Test
+    public void nonUidFolderAlwaysEmpty(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint(FINGERPRINT);
+        seed.put(ACCOUNT, FOLDER_NAME, new ScanState.FolderScanState(1L, 42L));
+        seed.save(stateFile);
+
+        Folder folder = plainFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+
+        assertThat(cache.getResumeUid(folder).isPresent()).isFalse();
+    }
+
+    @Test
+    public void noStateFileYetIsEmpty(@TempDir File dir) throws MessagingException
+    {
+        File stateFile = new File(dir, "does-not-exist.properties");
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+
+        assertThat(cache.getResumeUid(folder).isPresent()).isFalse();
+    }
+
+    @Test
+    public void mismatchedFingerprintIsEmptyEvenWithFolderEntry(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint("old-fingerprint");
+        seed.put(ACCOUNT, FOLDER_NAME, new ScanState.FolderScanState(1L, 42L));
+        seed.save(stateFile);
+
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+
+        assertThat(cache.getResumeUid(folder).isPresent()).isFalse();
+    }
+
+    @Test
+    public void matchingFingerprintButNoEntryForFolderIsEmpty(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint(FINGERPRINT);
+        seed.put(ACCOUNT, "SomeOtherFolder", new ScanState.FolderScanState(1L, 42L));
+        seed.save(stateFile);
+
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+
+        assertThat(cache.getResumeUid(folder).isPresent()).isFalse();
+    }
+
+    @Test
+    public void uidValidityMismatchIsEmpty(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint(FINGERPRINT);
+        seed.put(ACCOUNT, FOLDER_NAME, new ScanState.FolderScanState(999L, 42L));
+        seed.save(stateFile);
+
+        MockData.getInstance().setUidCapable(FOLDER_NAME, true);
+        MockData.getInstance().setUidValidity(FOLDER_NAME, 1L);
+        Folder folder = getStore().getFolder(FOLDER_NAME);
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+
+        assertThat(cache.getResumeUid(folder).isPresent()).isFalse();
+    }
+
+    @Test
+    public void matchingEverythingReturnsStoredNextUid(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint(FINGERPRINT);
+        seed.put(ACCOUNT, FOLDER_NAME, new ScanState.FolderScanState(1L, 42L));
+        seed.save(stateFile);
+
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+
+        assertThat(cache.getResumeUid(folder)).isEqualTo(java.util.OptionalLong.of(42L));
+    }
+
+    // --- recordScanCompletion ---
+
+    @Test
+    public void completedFullyPersistsSnapshottedEndUidNotCurrentUidNext(@TempDir File dir) throws MessagingException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "one"));
+        Folder folder = getStore().getFolder(FOLDER_NAME);
+
+        long endUidExclusive = data.getUidNext(FOLDER_NAME); // 2
+
+        // add another message AFTER snapshot but BEFORE recording completion
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-02", "b@example.com", "two"));
+        assertThat(data.getUidNext(FOLDER_NAME)).isGreaterThan(endUidExclusive);
+
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+        cache.recordScanCompletion(folder, endUidExclusive, null, true);
+
+        ScanState reloaded = ScanState.loadOrEmpty(stateFile);
+        assertThat(reloaded.get(ACCOUNT, FOLDER_NAME))
+                .hasValue(new ScanState.FolderScanState(1L, endUidExclusive));
+    }
+
+    @Test
+    public void incompleteScanWithLastConsideredPersistsItsUid(@TempDir File dir) throws MessagingException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        MockMessage first = MockMessage.create("2024-01-01", "a@example.com", "one");
+        MockMessage second = MockMessage.create("2024-01-02", "b@example.com", "two");
+        data.addMessage(FOLDER_NAME, first);
+        data.addMessage(FOLDER_NAME, second);
+        Folder folder = getStore().getFolder(FOLDER_NAME);
+        jakarta.mail.UIDFolder uidFolder = (jakarta.mail.UIDFolder) folder;
+        Message lastConsidered = uidFolder.getMessageByUID(1L);
+
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+        cache.recordScanCompletion(folder, 999L, lastConsidered, false);
+
+        ScanState reloaded = ScanState.loadOrEmpty(stateFile);
+        assertThat(reloaded.get(ACCOUNT, FOLDER_NAME))
+                .hasValue(new ScanState.FolderScanState(1L, 1L));
+    }
+
+    @Test
+    public void incompleteScanWithNoLastConsideredLeavesExistingStateUntouched(@TempDir File dir) throws MessagingException, IOException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        ScanState seed = new ScanState();
+        seed.setConfigFingerprint(FINGERPRINT);
+        seed.put(ACCOUNT, FOLDER_NAME, new ScanState.FolderScanState(1L, 42L));
+        seed.save(stateFile);
+
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+        cache.recordScanCompletion(folder, 999L, null, false);
+
+        ScanState reloaded = ScanState.loadOrEmpty(stateFile);
+        assertThat(reloaded.get(ACCOUNT, FOLDER_NAME))
+                .hasValue(new ScanState.FolderScanState(1L, 42L));
+        assertThat(reloaded.getConfigFingerprint()).isEqualTo(FINGERPRINT);
+    }
+
+    @Test
+    public void disabledRecordScanCompletionIsTrueNoOp(@TempDir File dir) throws MessagingException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, true);
+
+        cache.recordScanCompletion(folder, 100L, null, true);
+
+        assertThat(stateFile.exists()).isFalse();
+    }
+
+    @Test
+    public void nullStateFileRecordScanCompletionIsNoOp() throws MessagingException
+    {
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, null, FINGERPRINT, false);
+
+        cache.recordScanCompletion(folder, 100L, null, true);
+        // no exception thrown is the assertion
+    }
+
+    @Test
+    public void nonUidFolderRecordScanCompletionIsNoOp(@TempDir File dir) throws MessagingException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        Folder folder = plainFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+
+        cache.recordScanCompletion(folder, 100L, null, true);
+
+        assertThat(stateFile.exists()).isFalse();
+    }
+
+    @Test
+    public void ioFailureOnSaveIsSwallowedNotPropagated(@TempDir File dir) throws MessagingException
+    {
+        // Use a directory as the "state file" so writing to it fails with IOException.
+        File stateFileAsDirectory = new File(dir, "state-is-a-directory");
+        assertThat(stateFileAsDirectory.mkdirs()).isTrue();
+
+        Folder folder = uidFolder();
+        FolderScanCache cache = new DefaultFolderScanCache(ACCOUNT, stateFileAsDirectory, FINGERPRINT, false);
+
+        // Should not throw, despite the underlying save() failing.
+        cache.recordScanCompletion(folder, 100L, null, true);
+    }
+
+    @Test
+    public void freshCacheInstanceSeesPersistedStateAfterRecordScanCompletion(@TempDir File dir) throws MessagingException
+    {
+        File stateFile = new File(dir, "scan-state.properties");
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "one"));
+        Folder folder = getStore().getFolder(FOLDER_NAME);
+        long endUidExclusive = data.getUidNext(FOLDER_NAME);
+
+        FolderScanCache first = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+        first.recordScanCompletion(folder, endUidExclusive, null, true);
+
+        FolderScanCache second = new DefaultFolderScanCache(ACCOUNT, stateFile, FINGERPRINT, false);
+        Folder folderAgain = getStore().getFolder(FOLDER_NAME);
+
+        assertThat(second.getResumeUid(folderAgain)).isEqualTo(java.util.OptionalLong.of(endUidExclusive));
+    }
+}

--- a/src/test/java/org/ethelred/mymailtool2/MainTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/MainTest.java
@@ -1,13 +1,20 @@
 package org.ethelred.mymailtool2;
 
 import org.ethelred.util.ClockFactory;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.Mockito.*;
 
@@ -43,5 +50,94 @@ public class MainTest
 
         verify(conf, times(2)).getOperationLimit();
         verify(conf, times(1)).getTimeLimit();
+    }
+
+    /**
+     * DefaultConfiguration's default file locations point at real files on the running
+     * machine ($HOME/.mymailtoolrc.properties, /etc/mymailtoolrc.properties). To keep these
+     * fingerprint tests hermetic and independent of whatever happens to exist on the test
+     * host, we swap in a variant that reports no default file locations, so only the
+     * explicit -c file (plus command line / system properties, which never contribute file
+     * locations) feeds the fingerprint.
+     */
+    private static class NoDefaultFilesConfiguration extends DefaultConfiguration
+    {
+        @Override
+        public Iterable<String> getFileLocations()
+        {
+            return Collections.emptyList();
+        }
+    }
+
+    private static Main newMainForConfigFile(Path configFile)
+    {
+        Main main = new Main();
+        main.setDefaultConfiguration(new NoDefaultFilesConfiguration());
+        main.init(new String[] {"-c", configFile.toAbsolutePath().toString()});
+        return main;
+    }
+
+    private static Path writeMinimalConfig(Path dir, String fileName, String host) throws IOException
+    {
+        Path file = dir.resolve(fileName);
+        String content = "mail.store.protocol=imap\n"
+                + "mail.user=test@example.com\n"
+                + "mail.host=" + host + "\n";
+        Files.writeString(file, content, StandardCharsets.UTF_8);
+        return file;
+    }
+
+    @Test
+    public void testInitComputesNonNullConfigFingerprint(@TempDir Path tempDir) throws IOException
+    {
+        Path configFile = writeMinimalConfig(tempDir, "config.properties", "imap.example.com");
+
+        Main main = newMainForConfigFile(configFile);
+
+        assertThat(main.configFingerprint).isNotNull();
+    }
+
+    @Test
+    public void testInitProducesSameFingerprintForIdenticalConfigContent(@TempDir Path tempDir) throws IOException
+    {
+        // ConfigFingerprint hashes each file's (normalized) path as well as its content, by
+        // design (see ConfigFingerprint's javadoc), so two distinct file paths never hash
+        // equal even with byte-identical content. To isolate "identical content" as the only
+        // variable, we point two separate Main instances/init() calls at the very same,
+        // unchanged file.
+        Path configFile = writeMinimalConfig(tempDir, "config.properties", "imap.example.com");
+
+        Main mainA = newMainForConfigFile(configFile);
+        Main mainB = newMainForConfigFile(configFile);
+
+        assertThat(mainA.configFingerprint).isEqualTo(mainB.configFingerprint);
+    }
+
+    @Test
+    public void testInitProducesDifferentFingerprintForDifferentConfigContent(@TempDir Path tempDir) throws IOException
+    {
+        Path configFileA = writeMinimalConfig(tempDir, "configA.properties", "imap.example.com");
+        Path configFileB = writeMinimalConfig(tempDir, "configB.properties", "imap.other-example.com");
+
+        Main mainA = newMainForConfigFile(configFileA);
+        Main mainB = newMainForConfigFile(configFileB);
+
+        assertThat(mainA.configFingerprint).isNotEqualTo(mainB.configFingerprint);
+    }
+
+    @Test
+    public void testInitDetectsConfigFileContentChangeBetweenRuns(@TempDir Path tempDir) throws IOException
+    {
+        Path configFile = writeMinimalConfig(tempDir, "config.properties", "imap.example.com");
+
+        Main first = newMainForConfigFile(configFile);
+        String firstFingerprint = first.configFingerprint;
+
+        writeMinimalConfig(tempDir, "config.properties", "imap.changed-example.com");
+
+        Main second = newMainForConfigFile(configFile);
+        String secondFingerprint = second.configFingerprint;
+
+        assertThat(firstFingerprint).isNotEqualTo(secondFingerprint);
     }
 }

--- a/src/test/java/org/ethelred/mymailtool2/ScanStateTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/ScanStateTest.java
@@ -1,0 +1,133 @@
+package org.ethelred.mymailtool2;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * tests for ScanState
+ */
+public class ScanStateTest
+{
+    @Test
+    public void roundTripSavesAndLoadsFingerprintAndFolderEntries(@TempDir File dir) throws IOException
+    {
+        File file = new File(dir, "scan-state.properties");
+        ScanState state = new ScanState();
+        state.setConfigFingerprint("abc123");
+        state.put("jaq@example.com", "INBOX.Archive", new ScanState.FolderScanState(1690000000L, 48213L));
+        state.put("jaq@example.com", "INBOX", new ScanState.FolderScanState(1690000001L, 9981L));
+        state.put("other@example.com", "Some/Folder", new ScanState.FolderScanState(42L, 7L));
+
+        state.save(file);
+
+        ScanState loaded = ScanState.loadOrEmpty(file);
+
+        assertThat(loaded.getConfigFingerprint()).isEqualTo("abc123");
+        assertThat(loaded.get("jaq@example.com", "INBOX.Archive"))
+                .hasValue(new ScanState.FolderScanState(1690000000L, 48213L));
+        assertThat(loaded.get("jaq@example.com", "INBOX"))
+                .hasValue(new ScanState.FolderScanState(1690000001L, 9981L));
+        assertThat(loaded.get("other@example.com", "Some/Folder"))
+                .hasValue(new ScanState.FolderScanState(42L, 7L));
+    }
+
+    @Test
+    public void loadOrEmptyReturnsEmptyStateWhenFileMissing(@TempDir File dir)
+    {
+        File file = new File(dir, "does-not-exist.properties");
+
+        ScanState state = ScanState.loadOrEmpty(file);
+
+        assertThat(state.getConfigFingerprint()).isNull();
+        assertThat(state.get("someone@example.com", "INBOX")).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void loadOrEmptyReturnsEmptyStateWhenFileIsCorrupt(@TempDir File dir) throws IOException
+    {
+        File file = new File(dir, "corrupt.properties");
+        // bytes that will fail Properties.load due to invalid unicode escape
+        Files.write(file.toPath(), new byte[] {(byte) 0xFF, (byte) 0xFE, '\\', 'u', 'z', 'z', 'z', 'z'});
+
+        ScanState state = ScanState.loadOrEmpty(file);
+
+        assertThat(state.getConfigFingerprint()).isNull();
+        assertThat(state.get("someone@example.com", "INBOX")).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void loadOrEmptySkipsMalformedFolderEntryButKeepsOthers(@TempDir File dir) throws IOException
+    {
+        File file = new File(dir, "partial.properties");
+        String content = """
+                configFingerprint=fingerprint-value
+                folder.0.account=jaq@example.com
+                folder.0.name=INBOX
+                folder.0.uidValidity=100
+                folder.0.nextUid=200
+                folder.1.account=jaq@example.com
+                folder.1.name=Broken
+                folder.1.uidValidity=100
+                folder.1.nextUid=not-a-number
+                """;
+        Files.writeString(file.toPath(), content);
+
+        ScanState state = ScanState.loadOrEmpty(file);
+
+        assertThat(state.getConfigFingerprint()).isEqualTo("fingerprint-value");
+        assertThat(state.get("jaq@example.com", "INBOX"))
+                .hasValue(new ScanState.FolderScanState(100L, 200L));
+        assertThat(state.get("jaq@example.com", "Broken")).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void saveCreatesMissingParentDirectories(@TempDir File dir) throws IOException
+    {
+        File nested = new File(new File(dir, "nested/sub"), "scan-state.properties");
+        ScanState state = new ScanState();
+        state.setConfigFingerprint("fp");
+
+        state.save(nested);
+
+        assertThat(nested.exists()).isTrue();
+        ScanState loaded = ScanState.loadOrEmpty(nested);
+        assertThat(loaded.getConfigFingerprint()).isEqualTo("fp");
+    }
+
+    @Test
+    public void saveIsAtomicAndLeavesNoTempFile(@TempDir File dir) throws IOException
+    {
+        File file = new File(dir, "scan-state.properties");
+        File tmpFile = new File(dir, "scan-state.properties.tmp");
+        ScanState state = new ScanState();
+        state.setConfigFingerprint("fp-atomic");
+        state.put("jaq@example.com", "INBOX", new ScanState.FolderScanState(1L, 2L));
+
+        state.save(file);
+
+        assertThat(tmpFile.exists()).isFalse();
+        assertThat(file.exists()).isTrue();
+
+        ScanState loaded = ScanState.loadOrEmpty(file);
+        assertThat(loaded.getConfigFingerprint()).isEqualTo("fp-atomic");
+        assertThat(loaded.get("jaq@example.com", "INBOX"))
+                .hasValue(new ScanState.FolderScanState(1L, 2L));
+    }
+
+    @Test
+    public void getReturnsEmptyForUnknownFolder()
+    {
+        ScanState state = new ScanState();
+        state.put("jaq@example.com", "INBOX", new ScanState.FolderScanState(1L, 2L));
+
+        assertThat(state.get("jaq@example.com", "Other")).isEqualTo(Optional.empty());
+        assertThat(state.get("someone-else@example.com", "INBOX")).isEqualTo(Optional.empty());
+    }
+}

--- a/src/test/java/org/ethelred/mymailtool2/TaskBaseTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/TaskBaseTest.java
@@ -7,6 +7,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.CheckForNull;
+
 import jakarta.mail.Folder;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
@@ -16,6 +18,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * tests for base functionality
@@ -72,6 +75,45 @@ public class TaskBaseTest
 
     }
 
+    @Test
+    public void testOnFolderScanFinished_naturalCompletion() throws IOException, MessagingException
+    {
+        RecordingMockTaskBase tb = new RecordingMockTaskBase();
+        tb.giveUpAfter = Integer.MAX_VALUE;
+        tb.init(mockContext);
+        tb.traverseFolder("Folder", false, true);
+
+        assertThat(tb.finishedCallCount).isEqualTo(1);
+        assertThat(tb.recordedCompletedFully).isTrue();
+        assertThat(tb.recordedLastConsidered).isSameInstanceAs(tb.lastRunMessage);
+    }
+
+    @Test
+    public void testOnFolderScanFinished_shortcut() throws IOException, MessagingException
+    {
+        RecordingMockTaskBase tb = new RecordingMockTaskBase();
+        tb.init(mockContext);
+        tb.traverseFolder("Folder", false, true);
+
+        assertThat(tb.finishedCallCount).isEqualTo(1);
+        assertThat(tb.recordedCompletedFully).isFalse();
+        assertThat(tb.recordedLastConsidered).isSameInstanceAs(tb.lastRunMessage);
+    }
+
+    @Test
+    public void testOnFolderScanFinished_nonShortcutExceptionPropagates() throws IOException, MessagingException
+    {
+        RecordingMockTaskBase tb = new RecordingMockTaskBase();
+        tb.throwRuntimeExceptionAfter = 1;
+        tb.init(mockContext);
+
+        assertThrows(RuntimeException.class, () -> tb.traverseFolder("Folder", false, true));
+
+        assertThat(tb.finishedCallCount).isEqualTo(1);
+        assertThat(tb.recordedCompletedFully).isFalse();
+        assertThat(tb.recordedLastConsidered).isSameInstanceAs(tb.lastRunMessage);
+    }
+
     private class MockTaskBase extends TaskBase
     {
         int giveUpAfter = 1;
@@ -84,6 +126,55 @@ public class TaskBaseTest
             {
                 throw new ShortcutFolderScanException();
             }
+        }
+
+        @Override
+        protected void status(Folder f)
+        {
+
+            LOGGER.info("Status folder {}", f);
+        }
+
+        @Override
+        public void run()
+        {
+
+        }
+    }
+
+    private class RecordingMockTaskBase extends TaskBase
+    {
+        int giveUpAfter = 1;
+        int messageCounter;
+        Integer throwRuntimeExceptionAfter;
+        Message lastRunMessage;
+
+        int finishedCallCount;
+        boolean recordedCompletedFully;
+        Message recordedLastConsidered;
+
+        @Override
+        protected void runMessage(Folder f, Message m) throws MessagingException, IOException
+        {
+            lastRunMessage = m;
+            LOGGER.info("Check message {}", messageCounter);
+            int count = messageCounter++;
+            if (throwRuntimeExceptionAfter != null && count >= throwRuntimeExceptionAfter)
+            {
+                throw new RuntimeException("boom");
+            }
+            if (count > giveUpAfter)
+            {
+                throw new ShortcutFolderScanException();
+            }
+        }
+
+        @Override
+        protected void onFolderScanFinished(Folder f, boolean completedFully, @CheckForNull Message lastConsidered)
+        {
+            finishedCallCount++;
+            recordedCompletedFully = completedFully;
+            recordedLastConsidered = lastConsidered;
         }
 
         @Override

--- a/src/test/java/org/ethelred/mymailtool2/UidRangeMessageIterableTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/UidRangeMessageIterableTest.java
@@ -1,0 +1,211 @@
+package org.ethelred.mymailtool2;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.UIDFolder;
+
+import com.google.common.collect.Lists;
+import org.ethelred.mymailtool2.mock.MockAuthenticator;
+import org.ethelred.mymailtool2.mock.MockData;
+import org.ethelred.mymailtool2.mock.MockMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Tests for {@link UidRangeMessageIterable}.
+ */
+public class UidRangeMessageIterableTest
+{
+    private static final String FOLDER_NAME = "UidRangeTestFolder";
+
+    private Store getStore() throws MessagingException
+    {
+        Properties props = new Properties();
+        props.setProperty("mail.store.protocol", "imap");
+        Session ss = Session.getDefaultInstance(props, new MockAuthenticator());
+        return ss.getStore();
+    }
+
+    @BeforeEach
+    public void setUp()
+    {
+        MockData.clear();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        MockData.clear();
+    }
+
+    private void addMessages(MockData data, int count)
+    {
+        for (int i = 1; i <= count; i++)
+        {
+            data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-0" + i, "sender" + i + "@example.com", "message " + i));
+        }
+    }
+
+    private List<Message> drain(Iterable<Message> iterable)
+    {
+        return Lists.newArrayList(iterable);
+    }
+
+    @Test
+    public void iteratesAllMessagesAscendingFromStartUidOne() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        addMessages(data, 5);
+
+        Store store = getStore();
+        Folder folder = store.getFolder(FOLDER_NAME);
+
+        UidRangeMessageIterable iterable = new UidRangeMessageIterable(folder, 1L);
+        List<Message> messages = drain(iterable);
+
+        assertThat(messages).hasSize(5);
+        for (int i = 0; i < 5; i++)
+        {
+            assertThat(((UIDFolder) folder).getUID(messages.get(i))).isEqualTo(i + 1L);
+        }
+    }
+
+    @Test
+    public void iteratesOnlyMessagesFromPartwayStartUid() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        addMessages(data, 5);
+
+        Store store = getStore();
+        Folder folder = store.getFolder(FOLDER_NAME);
+
+        UidRangeMessageIterable iterable = new UidRangeMessageIterable(folder, 3L);
+        List<Message> messages = drain(iterable);
+
+        assertThat(messages).hasSize(3);
+        assertThat(((UIDFolder) folder).getUID(messages.get(0))).isEqualTo(3L);
+        assertThat(((UIDFolder) folder).getUID(messages.get(1))).isEqualTo(4L);
+        assertThat(((UIDFolder) folder).getUID(messages.get(2))).isEqualTo(5L);
+    }
+
+    @Test
+    public void emptyRangeWhenStartUidAtOrPastSnapshotYieldsNoMessages() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        addMessages(data, 3);
+
+        Store store = getStore();
+        Folder folder = store.getFolder(FOLDER_NAME);
+
+        // uidNext is 4 after adding 3 messages; starting at 4 (or beyond) means nothing new
+        UidRangeMessageIterable iterable = new UidRangeMessageIterable(folder, 4L);
+
+        Iterator<Message> it = iterable.iterator();
+        assertThat(it.hasNext()).isFalse();
+    }
+
+    @Test
+    public void emptyFolderYieldsNoMessages() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+
+        Store store = getStore();
+        Folder folder = store.getFolder(FOLDER_NAME);
+
+        UidRangeMessageIterable iterable = new UidRangeMessageIterable(folder, 1L);
+
+        assertThat(drain(iterable)).isEmpty();
+    }
+
+    @Test
+    public void messagesAddedAfterConstructionAreExcludedFromIteration() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        addMessages(data, 3);
+
+        Store store = getStore();
+        Folder folder = store.getFolder(FOLDER_NAME);
+
+        UidRangeMessageIterable iterable = new UidRangeMessageIterable(folder, 1L);
+        long snapshotEnd = iterable.getEndUidExclusive();
+
+        // simulate new mail arriving between construction and iteration
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-02-01", "late@example.com", "late arrival"));
+
+        List<Message> messages = drain(iterable);
+
+        assertThat(messages).hasSize(3);
+        for (Message m : messages)
+        {
+            long uid = ((UIDFolder) folder).getUID(m);
+            assertThat(uid).isLessThan(snapshotEnd);
+        }
+        for (Message m : messages)
+        {
+            assertThat(m.getSubject()).isNotEqualTo("late arrival");
+        }
+    }
+
+    @Test
+    public void getEndUidExclusiveIsSnapshotAndDoesNotChange() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        addMessages(data, 2);
+
+        Store store = getStore();
+        Folder folder = store.getFolder(FOLDER_NAME);
+
+        UidRangeMessageIterable iterable = new UidRangeMessageIterable(folder, 1L);
+        long before = iterable.getEndUidExclusive();
+        assertThat(before).isEqualTo(3L);
+
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-03-01", "another@example.com", "another"));
+
+        long after = iterable.getEndUidExclusive();
+        assertThat(after).isEqualTo(before);
+    }
+
+    @Test
+    public void nonUidFolderThrowsIllegalArgumentException() throws MessagingException
+    {
+        // do not mark folder as UID-capable, so store returns a plain (non-UIDFolder) MockFolder
+        Store store = getStore();
+        Folder folder = store.getFolder(FOLDER_NAME);
+
+        assertThrows(IllegalArgumentException.class, () -> new UidRangeMessageIterable(folder, 1L));
+    }
+
+    @Test
+    public void iteratorRemoveThrowsUnsupportedOperationException() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        addMessages(data, 2);
+
+        Store store = getStore();
+        Folder folder = store.getFolder(FOLDER_NAME);
+
+        UidRangeMessageIterable iterable = new UidRangeMessageIterable(folder, 1L);
+        Iterator<Message> it = iterable.iterator();
+        it.next();
+
+        assertThrows(UnsupportedOperationException.class, it::remove);
+    }
+}

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockData.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockData.java
@@ -44,6 +44,11 @@ public final class MockData
     }
 
     private Map<String, List<MockMessage>> folderMessages = Maps.newHashMap();
+    private Map<String, Long> uidValidity = Maps.newHashMap();
+    private Map<String, Long> nextUid = Maps.newHashMap();
+    private Map<String, Boolean> uidCapable = Maps.newHashMap();
+
+    private static final long DEFAULT_UID_VALIDITY = 1L;
 
 
     public void addFolder(String sName)
@@ -69,9 +74,101 @@ public final class MockData
     {
         folder = _checkName(folder);
         addFolder(folder);
+        long assignedUid = nextUid.getOrDefault(folder, 1L);
+        message.setUid(assignedUid);
+        nextUid.put(folder, assignedUid + 1);
         folderMessages.get(folder).add(message);
         Collections.sort(folderMessages.get(folder), DATE_SORT);
                         //System.err.println(folder + " add message " + message);
+    }
+
+    public long getUidValidity(String folderName)
+    {
+        folderName = _checkName(folderName);
+        return uidValidity.getOrDefault(folderName, DEFAULT_UID_VALIDITY);
+    }
+
+    public void setUidValidity(String folderName, long value)
+    {
+        folderName = _checkName(folderName);
+        uidValidity.put(folderName, value);
+    }
+
+    public long getUidNext(String folderName)
+    {
+        folderName = _checkName(folderName);
+        return nextUid.getOrDefault(folderName, 1L);
+    }
+
+    public boolean isUidCapable(String folderName)
+    {
+        folderName = _checkName(folderName);
+        return uidCapable.getOrDefault(folderName, false);
+    }
+
+    public void setUidCapable(String folderName, boolean capable)
+    {
+        folderName = _checkName(folderName);
+        uidCapable.put(folderName, capable);
+    }
+
+    public MockMessage findMessageByUid(String folderName, long uid)
+    {
+        folderName = _checkName(folderName);
+        List<MockMessage> messages = folderMessages.get(folderName);
+        if (messages == null)
+        {
+            return null;
+        }
+        for (MockMessage m : messages)
+        {
+            if (m.getUid() == uid)
+            {
+                return m;
+            }
+        }
+        return null;
+    }
+
+    public List<MockMessage> getMessagesByUidRange(String folderName, long startUid, long endUidInclusive)
+    {
+        folderName = _checkName(folderName);
+        List<MockMessage> messages = folderMessages.get(folderName);
+        List<MockMessage> result = Lists.newArrayList();
+        if (messages == null)
+        {
+            return result;
+        }
+        long end = endUidInclusive;
+        if (end == jakarta.mail.UIDFolder.LASTUID)
+        {
+            end = Long.MAX_VALUE;
+        }
+        for (MockMessage m : messages)
+        {
+            if (m.getUid() >= startUid && m.getUid() <= end)
+            {
+                result.add(m);
+            }
+        }
+        Collections.sort(result, Comparator.comparingLong(MockMessage::getUid));
+        return result;
+    }
+
+    /**
+     * Returns the 1-based sequence number of a message within a folder, as used by
+     * {@link MockFolder#getMessage(int)}, or -1 if not found.
+     */
+    public int indexOfMessage(String folderName, MockMessage message)
+    {
+        folderName = _checkName(folderName);
+        List<MockMessage> messages = folderMessages.get(folderName);
+        if (messages == null)
+        {
+            return -1;
+        }
+        int idx = messages.indexOf(message);
+        return idx < 0 ? -1 : idx + 1;
     }
 
     public boolean hasFolder(String name)
@@ -112,6 +209,9 @@ public final class MockData
     public static void clear()
     {
         getInstance().folderMessages.clear();
+        getInstance().uidValidity.clear();
+        getInstance().nextUid.clear();
+        getInstance().uidCapable.clear();
     }
 
     private static final class SingletonHolder

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockData.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockData.java
@@ -47,6 +47,7 @@ public final class MockData
     private Map<String, Long> uidValidity = Maps.newHashMap();
     private Map<String, Long> nextUid = Maps.newHashMap();
     private Map<String, Boolean> uidCapable = Maps.newHashMap();
+    private Map<String, Boolean> uidNextFailure = Maps.newHashMap();
 
     private static final long DEFAULT_UID_VALIDITY = 1L;
 
@@ -110,6 +111,24 @@ public final class MockData
     {
         folderName = _checkName(folderName);
         uidCapable.put(folderName, capable);
+    }
+
+    /**
+     * Test hook: when set, {@link MockUidFolder#getUIDNext()} for {@code folderName} throws a
+     * {@link jakarta.mail.MessagingException} instead of returning normally, simulating a
+     * transient IMAP failure at exactly that call (e.g. the snapshot taken inside
+     * {@code UidRangeMessageIterable}'s constructor).
+     */
+    public void setUidNextFailure(String folderName, boolean fail)
+    {
+        folderName = _checkName(folderName);
+        uidNextFailure.put(folderName, fail);
+    }
+
+    public boolean shouldFailUidNext(String folderName)
+    {
+        folderName = _checkName(folderName);
+        return uidNextFailure.getOrDefault(folderName, false);
     }
 
     public MockMessage findMessageByUid(String folderName, long uid)
@@ -212,6 +231,7 @@ public final class MockData
         getInstance().uidValidity.clear();
         getInstance().nextUid.clear();
         getInstance().uidCapable.clear();
+        getInstance().uidNextFailure.clear();
     }
 
     private static final class SingletonHolder

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockDefaultConfiguration.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockDefaultConfiguration.java
@@ -98,6 +98,18 @@ public class MockDefaultConfiguration implements MailToolConfiguration
         return false;
     }
 
+    @Override
+    public String getScanStateFile()
+    {
+        return null;
+    }
+
+    @Override
+    public boolean disableScanCache()
+    {
+        return false;
+    }
+
     public void addFileHandler(FileConfigurationHandler fileConfigurationHandler)
     {
         defaultFileHandlers.add(fileConfigurationHandler);

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockFolder.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockFolder.java
@@ -134,15 +134,27 @@ public class MockFolder extends Folder
     @Override
     public Message getMessage(int i) throws MessagingException
     {
-        if (msgCache.containsKey(i)) {
-            return msgCache.get(i);
-        }
         MockMessage mm = data.getMessage(name, i);
         if (mm == null) {
             throw new MessagingException();
         }
-        Message result = mm.getMimeMessage(this, i);
-        msgCache.put(i, result);
+        return getOrCreateCachedMessage(i, mm);
+    }
+
+    /**
+     * Returns the cached {@link Message} wrapper for the given sequence number, creating and
+     * caching it via {@link MockMessage#getMimeMessage} if not already cached. Any code path that
+     * wraps a {@link MockMessage} into a {@link Message} for this folder (whether addressed by
+     * sequence number or by some other means, e.g. UID) must go through this method so that
+     * {@link #expunge()} (which only inspects {@link #msgCache}) can find it later.
+     */
+    protected Message getOrCreateCachedMessage(int seqNum, MockMessage mm) throws MessagingException
+    {
+        if (msgCache.containsKey(seqNum)) {
+            return msgCache.get(seqNum);
+        }
+        Message result = mm.getMimeMessage(this, seqNum);
+        msgCache.put(seqNum, result);
         return result;
     }
 

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockFolder.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockFolder.java
@@ -16,9 +16,9 @@ import com.google.common.collect.Maps;
  */
 public class MockFolder extends Folder
 {
-    private final String name;
+    protected final String name;
 
-    private final MockData data;
+    protected final MockData data;
     private Map<Integer, Message> msgCache = Maps.newHashMap();
 
     public MockFolder(Store store, MockData data, String name)

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockMessage.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockMessage.java
@@ -32,6 +32,7 @@ public final class MockMessage
     private Map<String, String> mockheaders = Maps.newHashMap();
     private List<Attachment> attachments = Lists.newArrayList();
     private Flags flags = new Flags();
+    private long uid;
 
     private record Attachment(String filename, byte[] content) {}
 
@@ -74,6 +75,16 @@ public final class MockMessage
     {
         flags.add(flag);
         return this;
+    }
+
+    long getUid()
+    {
+        return uid;
+    }
+
+    void setUid(long uid)
+    {
+        this.uid = uid;
     }
 
 

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockStore.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockStore.java
@@ -29,6 +29,10 @@ public class MockStore extends Store
     @Override
     public Folder getFolder(String s) throws MessagingException
     {
+        if (data.isUidCapable(s))
+        {
+            return new MockUidFolder(this, data, s);
+        }
         return new MockFolder(this, data, s);
     }
 

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolder.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolder.java
@@ -28,6 +28,10 @@ public class MockUidFolder extends MockFolder implements UIDFolder
     @Override
     public long getUIDNext() throws MessagingException
     {
+        if (data.shouldFailUidNext(name))
+        {
+            throw new MessagingException("Simulated transient getUIDNext() failure for " + name);
+        }
         return data.getUidNext(name);
     }
 

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolder.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolder.java
@@ -1,0 +1,84 @@
+package org.ethelred.mymailtool2.mock;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Store;
+import jakarta.mail.UIDFolder;
+
+/**
+ * A {@link MockFolder} that also implements {@link UIDFolder}, for tests that need
+ * IMAP-UID-capable folder behaviour.
+ */
+public class MockUidFolder extends MockFolder implements UIDFolder
+{
+    public MockUidFolder(Store store, MockData data, String name)
+    {
+        super(store, data, name);
+    }
+
+    @Override
+    public long getUIDValidity() throws MessagingException
+    {
+        return data.getUidValidity(name);
+    }
+
+    @Override
+    public long getUIDNext() throws MessagingException
+    {
+        return data.getUidNext(name);
+    }
+
+    @Override
+    public long getUID(Message message) throws MessagingException
+    {
+        MockMessage mm = MockMessage.getOuter(message);
+        if (mm == null)
+        {
+            throw new NoSuchElementException("Message is not from this folder");
+        }
+        return mm.getUid();
+    }
+
+    @Override
+    public Message getMessageByUID(long uid) throws MessagingException
+    {
+        MockMessage mm = data.findMessageByUid(name, uid);
+        if (mm == null)
+        {
+            return null;
+        }
+        return toMessage(mm);
+    }
+
+    @Override
+    public Message[] getMessagesByUID(long start, long end) throws MessagingException
+    {
+        List<MockMessage> messages = data.getMessagesByUidRange(name, start, end);
+        Message[] result = new Message[messages.size()];
+        for (int i = 0; i < messages.size(); i++)
+        {
+            result[i] = toMessage(messages.get(i));
+        }
+        return result;
+    }
+
+    @Override
+    public Message[] getMessagesByUID(long[] uids) throws MessagingException
+    {
+        Message[] result = new Message[uids.length];
+        for (int i = 0; i < uids.length; i++)
+        {
+            result[i] = getMessageByUID(uids[i]);
+        }
+        return result;
+    }
+
+    private Message toMessage(MockMessage mm) throws MessagingException
+    {
+        int seqNum = data.indexOfMessage(name, mm);
+        return mm.getMimeMessage(this, seqNum);
+    }
+}

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolder.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolder.java
@@ -35,7 +35,7 @@ public class MockUidFolder extends MockFolder implements UIDFolder
     public long getUID(Message message) throws MessagingException
     {
         MockMessage mm = MockMessage.getOuter(message);
-        if (mm == null)
+        if (mm == null || message.getFolder() != this)
         {
             throw new NoSuchElementException("Message is not from this folder");
         }
@@ -79,6 +79,6 @@ public class MockUidFolder extends MockFolder implements UIDFolder
     private Message toMessage(MockMessage mm) throws MessagingException
     {
         int seqNum = data.indexOfMessage(name, mm);
-        return mm.getMimeMessage(this, seqNum);
+        return getOrCreateCachedMessage(seqNum, mm);
     }
 }

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolderTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolderTest.java
@@ -1,7 +1,9 @@
 package org.ethelred.mymailtool2.mock;
 
+import java.util.NoSuchElementException;
 import java.util.Properties;
 
+import jakarta.mail.Flags;
 import jakarta.mail.Folder;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
@@ -14,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Tests for the UID-capable mock folder infrastructure.
@@ -174,6 +177,49 @@ public class MockUidFolderTest
 
         Message byUid = uf.getMessageByUID(1L);
         assertThat(uf.getUID(byUid)).isEqualTo(1L);
+    }
+
+    @Test
+    public void expungeFindsMessageFetchedByUid() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "one"));
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-02", "b@example.com", "two"));
+
+        Store store = getStore();
+        UIDFolder uf = (UIDFolder) store.getFolder(FOLDER_NAME);
+        MockFolder folder = (MockFolder) uf;
+
+        // fetch only via UID, never via sequence number, then flag deleted and expunge
+        Message m = uf.getMessageByUID(1L);
+        m.setFlag(Flags.Flag.DELETED, true);
+
+        Message[] expunged = folder.expunge();
+
+        assertThat(expunged).hasLength(1);
+        assertThat(expunged[0].getSubject()).isEqualTo("one");
+        assertThat(data.folderSize(FOLDER_NAME)).isEqualTo(1);
+        assertThat(data.getMessage(FOLDER_NAME, 1).toString()).contains("two");
+    }
+
+    @Test
+    public void getUIDThrowsForMessageFromAnotherFolder() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        String otherFolderName = "OtherUidFolder";
+        data.setUidCapable(FOLDER_NAME, true);
+        data.setUidCapable(otherFolderName, true);
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "in folder A"));
+        data.addMessage(otherFolderName, MockMessage.create("2024-01-01", "b@example.com", "in folder B"));
+
+        Store store = getStore();
+        UIDFolder folderA = (UIDFolder) store.getFolder(FOLDER_NAME);
+        UIDFolder folderB = (UIDFolder) store.getFolder(otherFolderName);
+
+        Message messageFromB = folderB.getMessageByUID(1L);
+
+        assertThrows(NoSuchElementException.class, () -> folderA.getUID(messageFromB));
     }
 
     @Test

--- a/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolderTest.java
+++ b/src/test/java/org/ethelred/mymailtool2/mock/MockUidFolderTest.java
@@ -1,0 +1,196 @@
+package org.ethelred.mymailtool2.mock;
+
+import java.util.Properties;
+
+import jakarta.mail.Folder;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Store;
+import jakarta.mail.UIDFolder;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.google.common.truth.Truth.assertThat;
+
+/**
+ * Tests for the UID-capable mock folder infrastructure.
+ */
+public class MockUidFolderTest
+{
+    private static final String FOLDER_NAME = "UidTestFolder";
+
+    private Store getStore() throws MessagingException
+    {
+        Properties props = new Properties();
+        props.setProperty("mail.store.protocol", "imap");
+        Session ss = Session.getDefaultInstance(props, new MockAuthenticator());
+        return ss.getStore();
+    }
+
+    @BeforeEach
+    public void setUp()
+    {
+        MockData.clear();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        MockData.clear();
+    }
+
+    @Test
+    public void nonUidCapableFolderIsPlainMockFolder() throws MessagingException
+    {
+        Store store = getStore();
+        Folder f = store.getFolder(FOLDER_NAME);
+
+        assertThat(f).isInstanceOf(MockFolder.class);
+        assertThat(f).isNotInstanceOf(UIDFolder.class);
+    }
+
+    @Test
+    public void uidCapableFolderIsMockUidFolder() throws MessagingException
+    {
+        MockData.getInstance().setUidCapable(FOLDER_NAME, true);
+        Store store = getStore();
+        Folder f = store.getFolder(FOLDER_NAME);
+
+        assertThat(f).isInstanceOf(MockFolder.class);
+        assertThat(f).isInstanceOf(UIDFolder.class);
+    }
+
+    @Test
+    public void messagesGetSequentialUidsInAddOrderNotDateOrder() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+
+        // add out of date order: second message has an earlier date than first
+        MockMessage first = MockMessage.create("2024-06-01", "a@example.com", "first added");
+        MockMessage second = MockMessage.create("2024-01-01", "b@example.com", "second added, earlier date");
+        MockMessage third = MockMessage.create("2024-12-01", "c@example.com", "third added");
+
+        data.addMessage(FOLDER_NAME, first);
+        data.addMessage(FOLDER_NAME, second);
+        data.addMessage(FOLDER_NAME, third);
+
+        assertThat(first.getUid()).isEqualTo(1L);
+        assertThat(second.getUid()).isEqualTo(2L);
+        assertThat(third.getUid()).isEqualTo(3L);
+    }
+
+    @Test
+    public void getUIDNextReflectsOneMoreThanHighestAssigned() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+
+        Store store = getStore();
+        UIDFolder f = (UIDFolder) store.getFolder(FOLDER_NAME);
+
+        assertThat(f.getUIDNext()).isEqualTo(1L);
+
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "one"));
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-02", "b@example.com", "two"));
+
+        assertThat(f.getUIDNext()).isEqualTo(3L);
+    }
+
+    @Test
+    public void getUIDValidityDefaultsAndCanBeChanged() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+
+        Store store = getStore();
+        UIDFolder f = (UIDFolder) store.getFolder(FOLDER_NAME);
+
+        long defaultValidity = f.getUIDValidity();
+        assertThat(defaultValidity).isEqualTo(1L);
+
+        data.setUidValidity(FOLDER_NAME, 42L);
+        assertThat(f.getUIDValidity()).isEqualTo(42L);
+    }
+
+    @Test
+    public void getMessageByUIDReturnsRightMessageOrNull() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "one"));
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-02", "b@example.com", "two"));
+
+        Store store = getStore();
+        UIDFolder f = (UIDFolder) store.getFolder(FOLDER_NAME);
+
+        Message m = f.getMessageByUID(2L);
+        assertThat(m).isNotNull();
+        assertThat(m.getSubject()).isEqualTo("two");
+
+        assertThat(f.getMessageByUID(999L)).isNull();
+    }
+
+    @Test
+    public void getMessagesByUIDRangeReturnsSubsetInAscendingOrder() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "one"));
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-02", "b@example.com", "two"));
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-03", "c@example.com", "three"));
+
+        Store store = getStore();
+        UIDFolder f = (UIDFolder) store.getFolder(FOLDER_NAME);
+
+        Message[] subset = f.getMessagesByUID(2L, 3L);
+        assertThat(subset).hasLength(2);
+        assertThat(subset[0].getSubject()).isEqualTo("two");
+        assertThat(subset[1].getSubject()).isEqualTo("three");
+
+        Message[] fromStart = f.getMessagesByUID(2L, UIDFolder.LASTUID);
+        assertThat(fromStart).hasLength(2);
+        assertThat(fromStart[0].getSubject()).isEqualTo("two");
+        assertThat(fromStart[1].getSubject()).isEqualTo("three");
+    }
+
+    @Test
+    public void getUIDRoundTripsForMessageFetchedBySeqNumOrUid() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "one"));
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-02", "b@example.com", "two"));
+
+        Store store = getStore();
+        UIDFolder uf = (UIDFolder) store.getFolder(FOLDER_NAME);
+        MockFolder folder = (MockFolder) uf;
+
+        Message bySeq = folder.getMessage(2);
+        assertThat(uf.getUID(bySeq)).isEqualTo(2L);
+
+        Message byUid = uf.getMessageByUID(1L);
+        assertThat(uf.getUID(byUid)).isEqualTo(1L);
+    }
+
+    @Test
+    public void clearResetsUidTrackingState() throws MessagingException
+    {
+        MockData data = MockData.getInstance();
+        data.setUidCapable(FOLDER_NAME, true);
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-01", "a@example.com", "one"));
+        data.addMessage(FOLDER_NAME, MockMessage.create("2024-01-02", "b@example.com", "two"));
+
+        assertThat(data.getUidNext(FOLDER_NAME)).isEqualTo(3L);
+
+        MockData.clear();
+
+        MockMessage freshFirst = MockMessage.create("2024-01-01", "a@example.com", "fresh one");
+        MockData.getInstance().addMessage(FOLDER_NAME, freshFirst);
+
+        assertThat(freshFirst.getUid()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds an incremental scan cache so `ApplyMatchOperationsTask` skips re-scanning old, already-considered messages on repeat runs (e.g. from cron), instead of rescanning every message in every configured folder every time.
- Persists a per-account/per-folder IMAP UID high-water-mark + UIDVALIDITY (`ScanState`), invalidated wholesale by a SHA-256 fingerprint over all loaded config files (`ConfigFingerprint`) and per-folder by UIDVALIDITY changes. Decision logic lives in `FolderScanCache`/`DefaultFolderScanCache`.
- A message that only triggered an internal "shortcut" (e.g. an age-based rule not yet satisfied) is correctly treated as unresolved and re-examined in a future run once conditions change — this was the trickiest correctness property and has a dedicated regression test.
- New `--no-scan-cache` CLI flag (+ properties/JS config equivalents) to force a full rescan; zero behavior change for `SearchTask`/`ListFoldersTask`/`SplitTask` or any pre-existing caller.
- Known, accepted limitation and a couple of operational caveats (stale folder entries, no concurrent-run locking) are documented in the README.

## Test Plan
- [x] `./gradlew clean test` — 141 tests, 0 failures
- [x] Each of the 10 implementation stages was independently spec-reviewed and code-quality-reviewed with fix/re-review cycles (including one real correctness bug caught in Stage 8: an unchecked-exception escape path that could abort a whole run instead of degrading to a full scan for one folder)
- [x] A final whole-branch review was done after all stages landed, checking cross-stage consistency and integration gaps
- [x] JaCoCo coverage for new classes: ScanState 97%, DefaultFolderScanCache 100%, ConfigFingerprint 100%, UidRangeMessageIterable 89%

🤖 Generated with [Claude Code](https://claude.com/claude-code)